### PR TITLE
Armory and kitchen layout fixes

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2549,11 +2549,11 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "aiy" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
@@ -2784,14 +2784,10 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "ajb" = (
-/obj/machinery/cryopod{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/delivery/white{
-	color = "#00ff00";
-	name = "green"
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/white,
 /area/security/prison)
 "ajc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -50737,12 +50733,6 @@
 /obj/item/storage/backpack/duffelbag,
 /turf/open/floor/iron/dark,
 /area/commons/dorms)
-"ota" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/security/prison)
 "ots" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -56152,7 +56142,10 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
 /area/security/prison)
 "sZP" = (
 /obj/structure/closet,
@@ -81097,7 +81090,7 @@ agF
 agF
 agF
 iPU
-ajb
+aiZ
 siC
 aiZ
 aiZ
@@ -81613,8 +81606,8 @@ agV
 ahl
 ahz
 ahX
-ota
-aeU
+ahz
+ajb
 ajI
 akz
 alo

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -41086,6 +41086,10 @@
 /obj/machinery/vending/medical,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"fXK" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply,
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "fYY" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -48479,6 +48483,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"mxU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "mxV" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/green,
@@ -108695,9 +108705,9 @@ mES
 mES
 mES
 ePI
-mES
-bmu
-bmu
+fXK
+mxU
+mxU
 bmu
 bmu
 bmu

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -35048,10 +35048,7 @@
 /area/service/bar)
 "cpm" = (
 /obj/structure/table,
-/obj/item/knife{
-	pixel_x = -13
-	},
-/obj/item/serviette_pack,
+/obj/item/knife,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "cpn" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -35051,7 +35051,6 @@
 /obj/item/knife{
 	pixel_x = -13
 	},
-/obj/item/knife/butcher,
 /obj/item/serviette_pack,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -40658,6 +40658,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
+"fBT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "fDg" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "IsolationCell";
@@ -41086,10 +41092,6 @@
 /obj/machinery/vending/medical,
 /turf/open/floor/iron/white,
 /area/medical/virology)
-"fXK" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply,
-/turf/closed/wall/r_wall,
-/area/science/mixing)
 "fYY" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -46512,6 +46514,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/cytology)
+"kPF" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply,
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "kPV" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -48483,12 +48489,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"mxU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/science/mixing/chamber)
 "mxV" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/tile/green,
@@ -58910,7 +58910,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "viN" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_ordmix{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "vjH" = (
@@ -108705,9 +108707,9 @@ mES
 mES
 mES
 ePI
-fXK
-mxU
-mxU
+kPF
+fBT
+fBT
 bmu
 bmu
 bmu

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -15638,12 +15638,19 @@
 /obj/machinery/light/directional/north,
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/item/storage/box/donkpockets,
+/obj/item/clothing/head/chefhat,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aYV" = (
 /obj/structure/table,
-/obj/item/storage/box/donkpockets,
-/obj/item/clothing/head/chefhat,
+/obj/item/plate/oven_tray,
+/obj/item/plate/oven_tray{
+	pixel_y = 2
+	},
+/obj/item/plate/oven_tray{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aYX" = (
@@ -16773,10 +16780,18 @@
 	desc = "Used to grind things up into raw materials and liquids.";
 	pixel_y = 5
 	},
+/obj/item/storage/box/beakers{
+	pixel_x = -4;
+	pixel_y = -5
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bch" = (
 /obj/machinery/oven,
+/obj/machinery/pollution_scrubber{
+	pixel_x = 16;
+	pixel_y = 15
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bck" = (
@@ -35033,14 +35048,11 @@
 /area/service/bar)
 "cpm" = (
 /obj/structure/table,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -8;
-	pixel_y = 5
+/obj/item/knife{
+	pixel_x = -13
 	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = -8
-	},
-/obj/item/knife/kitchen,
+/obj/item/knife/butcher,
+/obj/item/serviette_pack,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "cpn" = (
@@ -36940,6 +36952,9 @@
 	dir = 4
 	},
 /obj/item/holosign_creator/robot_seat/bar,
+/obj/machinery/pollution_scrubber{
+	pixel_x = -15
+	},
 /turf/open/floor/iron/dark,
 /area/service/bar)
 "cyP" = (
@@ -55096,6 +55111,13 @@
 	dir = 8
 	},
 /obj/structure/displaycase/forsale/kitchen,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
 "sbS" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2545,6 +2545,7 @@
 "aix" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/darkblue/corner,
+/obj/vehicle/ridden/secway,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "aiy" = (
@@ -2687,8 +2688,8 @@
 /area/ai_monitored/security/armory)
 "aiM" = (
 /obj/effect/turf_decal/bot_blue,
-/obj/structure/rack,
 /obj/effect/spawner/armory_spawn/shotguns,
+/obj/structure/rack/gunrack,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "aiN" = (
@@ -2811,6 +2812,29 @@
 /area/security/brig)
 "ajg" = (
 /obj/structure/rack,
+/obj/effect/turf_decal/bot_blue,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_y = 2
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_y = 2
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 3;
+	pixel_y = 2
+	},
 /obj/item/shield/riot{
 	pixel_x = -3;
 	pixel_y = 3
@@ -2820,7 +2844,6 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/bot_blue,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ajj" = (
@@ -3013,17 +3036,6 @@
 /area/security/brig)
 "ajP" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 2
-	},
 /obj/item/clothing/suit/armor/bulletproof{
 	pixel_x = 3;
 	pixel_y = -2
@@ -3036,6 +3048,17 @@
 	pixel_y = -2
 	},
 /obj/effect/turf_decal/bot_blue,
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = 3;
+	pixel_y = -2
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_y = -2
+	},
+/obj/item/clothing/head/helmet/alt{
+	pixel_x = -3;
+	pixel_y = -2
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ajQ" = (
@@ -3059,6 +3082,9 @@
 "ajT" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
+/obj/item/storage/box/emps{
+	pixel_y = 11
+	},
 /obj/item/gun/energy/temperature/security,
 /obj/item/clothing/suit/hooded/ablative,
 /obj/effect/turf_decal/bot_blue,
@@ -3358,29 +3384,29 @@
 /area/security/brig)
 "akL" = (
 /obj/structure/rack,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_y = 2
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_y = -2
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = -3;
-	pixel_y = -2
-	},
 /obj/effect/turf_decal/bot_blue,
+/obj/item/clothing/head/helmet{
+	layer = 3.00001;
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "akM" = (
@@ -3416,6 +3442,16 @@
 	name = "Armory Shutters";
 	pixel_x = 26;
 	req_access_txt = "3"
+	},
+/obj/structure/rack,
+/obj/item/storage/box/rubbershot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/storage/box/rubbershot,
+/obj/item/storage/box/rubbershot{
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -3649,6 +3685,13 @@
 /area/security/office)
 "alD" = (
 /obj/structure/table/wood,
+/obj/item/flashlight/seclite{
+	pixel_y = 8
+	},
+/obj/item/flashlight/seclite{
+	pixel_y = 4
+	},
+/obj/item/flashlight/seclite,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "alF" = (
@@ -3944,6 +3987,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -1
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -52825,9 +52871,9 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "qgK" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/bot_blue,
 /obj/effect/spawner/armory_spawn/microfusion,
+/obj/structure/rack/gunrack,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "qgQ" = (
@@ -55134,6 +55180,7 @@
 /obj/effect/turf_decal/trimline/darkblue/line{
 	dir = 1
 	},
+/obj/item/key/security,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "sdV" = (
@@ -57530,9 +57577,12 @@
 	name = "contraband locker";
 	req_access_txt = "3"
 	},
-/obj/effect/spawner/random/maintenance/three,
+/obj/effect/spawner/random/contraband/armory,
+/obj/effect/spawner/random/contraband/armory,
+/obj/effect/spawner/random/contraband/armory,
 /obj/effect/spawner/random/contraband/armory,
 /obj/item/gun/ballistic/rifle/boltaction,
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ulY" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3082,9 +3082,6 @@
 "ajT" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
-/obj/item/storage/box/emps{
-	pixel_y = 11
-	},
 /obj/item/gun/energy/temperature/security,
 /obj/item/clothing/suit/hooded/ablative,
 /obj/effect/turf_decal/bot_blue,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes some of the layout in the armoury, mostly by giving them the gun rack and some other tools to be consistent with other maps

Kitchen just gets a few missing items

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Gun racks and rubbershot to the armoury
add: secway and key in secstorage
add: Secmasks and seclights to the table in the office
add: complete sets of all standard sec armour types in armoury
add: oventrays, box of beakers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
