### PR TITLE
Adds Xenospawns and fixes an atmos problem

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2118,10 +2118,9 @@
 /turf/open/floor/carpet,
 /area/command/heads_quarters/captain/private)
 "aho" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
 "ahp" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
@@ -3360,7 +3359,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
@@ -4918,13 +4916,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "api" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/maintenance/department/crew_quarters/dorms)
 "apj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12806,10 +12801,10 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "aQg" = (
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
 "aQh" = (
 /obj/machinery/light/directional/north,
 /obj/structure/cable,
@@ -22683,16 +22678,12 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "bvL" = (
-/obj/machinery/power/apc/highcap/ten_k{
-	auto_name = 1;
-	dir = 1;
-	pixel_y = 23
-	},
 /obj/machinery/firealarm/directional/west,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "bvM" = (
@@ -28347,11 +28338,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bPS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/department/cargo)
 "bPT" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -28690,7 +28679,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bQG" = (
-/obj/structure/reagent_dispensers/fueltank/large,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -28905,7 +28893,6 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bRu" = (
-/obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
@@ -29148,22 +29135,27 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bSc" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/reagent_dispensers/fueltank/large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bSd" = (
-/obj/structure/reagent_dispensers/foamtank,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
+	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bSe" = (
@@ -29769,14 +29761,9 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "bTH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -29784,7 +29771,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -29801,7 +29787,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -29814,7 +29799,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -29847,6 +29831,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/light/directional/south,
+/obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "bTR" = (
@@ -30032,7 +30017,7 @@
 /area/engineering/atmos)
 "bUr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -38957,6 +38942,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/dark,
 /area/commons/fitness)
 "ecW" = (
@@ -39929,6 +39915,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"fbj" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "fbr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -42037,6 +42030,13 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/maintenance/department/engine)
+"gNi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gNv" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -46656,6 +46656,7 @@
 "kUU" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "kVc" = (
@@ -48966,6 +48967,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"mUY" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Monitoring";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/engineering/lobby)
 "mVv" = (
 /obj/structure/bed/dogbed/ian,
 /obj/item/toy/figure/ian,
@@ -50354,6 +50366,7 @@
 /area/medical/virology)
 "oaG" = (
 /obj/item/wirerod,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
 "oaS" = (
@@ -51611,6 +51624,7 @@
 "paM" = (
 /obj/item/stack/sheet/animalhide/xeno,
 /obj/item/clothing/under/rank/civilian/janitor/maid,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -51919,7 +51933,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/machinery/button/ignition/incinerator/ordmix{
 	pixel_y = -24
@@ -52084,16 +52097,11 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "pzM" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Monitoring";
-	req_access_txt = "24"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/engineering/lobby)
+/area/engineering/atmos)
 "pzR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -52355,7 +52363,6 @@
 /area/science/xenobiology)
 "pJc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -52805,7 +52812,6 @@
 /area/service/salon)
 "qcA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
@@ -54952,6 +54958,7 @@
 /area/science/storage)
 "rSH" = (
 /obj/item/trash/can,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
 "rSQ" = (
@@ -55383,6 +55390,10 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/grass,
 /area/medical/psychology)
+"soM" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "spo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55770,6 +55781,12 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
+"sJo" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/engine)
 "sJp" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -59194,6 +59211,7 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "vtT" = (
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
 "vtX" = (
@@ -59729,6 +59747,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
+"vSL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vSQ" = (
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -59844,6 +59872,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"wbw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "wby" = (
 /obj/structure/dresser,
 /turf/open/floor/iron/grimy,
@@ -78560,7 +78602,7 @@ aiu
 wRI
 ajD
 ajD
-ajD
+aho
 aoK
 aBa
 xyB
@@ -80103,7 +80145,7 @@ aof
 aiu
 aqh
 lqc
-aoe
+aQg
 atq
 aut
 aiu
@@ -81727,7 +81769,7 @@ bJb
 bJb
 bJb
 bJb
-bJb
+wbw
 bJb
 bPp
 bva
@@ -87127,7 +87169,7 @@ bPC
 bDi
 bva
 bPA
-bSw
+sJo
 bSw
 bXV
 bDi
@@ -87381,7 +87423,7 @@ jFD
 bNK
 bSv
 bTj
-bDi
+soM
 bva
 tRc
 bVz
@@ -89095,7 +89137,7 @@ amv
 alJ
 anS
 aiR
-api
+aph
 ajM
 aqC
 ary
@@ -97137,9 +97179,9 @@ bOg
 bRs
 vfl
 gJV
-bRs
+fbj
 bSb
-pzM
+qOx
 bTH
 bUp
 bVe
@@ -97653,9 +97695,9 @@ bPP
 bQG
 bRu
 bSd
-qOx
-bTJ
-urG
+mUY
+vSL
+gNi
 bMf
 bMf
 bMf
@@ -98420,9 +98462,9 @@ bLZ
 bNd
 bOl
 bTM
-aho
-aho
-aho
+bTM
+bTM
+bTM
 qcA
 pJc
 akJ
@@ -98674,10 +98716,10 @@ bIC
 bJK
 bJN
 bMa
-bMf
+pzM
 bOk
 bMf
-bPS
+bMf
 bMf
 bMf
 bMf
@@ -103770,7 +103812,7 @@ mAV
 aMv
 aNQ
 cDa
-aQg
+aTq
 aTq
 aTq
 aTq
@@ -106316,7 +106358,7 @@ cVo
 cVo
 cVo
 gtF
-cVo
+api
 adL
 meX
 aei
@@ -107639,7 +107681,7 @@ sut
 aaa
 aaa
 aEj
-aFi
+bPS
 bfM
 aEj
 bhz


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds enough xeno spawners to get the event to fire which fixes #212 

Potentially fixes the jumpy or empty gas problem by recycling waste CO2 as per delta/metastation, its pretty speculative whether this will help anything, im of the opinion that this is a problem that should be solved by atmostechs, however, atmos can be a big task for newer players to tackle, so im looking at tackling it with solutions provided via other maps

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: xenospawns work, meaning we can get aliens and spiders again
add: Co2 filter that feeds back to scrubbing loop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
