### PR TITLE
Furranium purity fix

### DIFF
--- a/modular_tannhauser/modules/CitOwOChems/code/chemistry/reagents/furrrrrr.dm
+++ b/modular_tannhauser/modules/CitOwOChems/code/chemistry/reagents/furrrrrr.dm
@@ -12,6 +12,7 @@
 	taste_description = "dewicious degenyewacy"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	inverse_chem_val 		= 0
+	purity = 0.9
 	var/obj/item/organ/tongue/nT
 	chemical_flags = REAGENT_DONOTSPLIT | REAGENT_CAN_BE_SYNTHESIZED
 	ph = 5
@@ -79,7 +80,7 @@
 	..()
 
 /datum/reagent/OwO/furranium/on_mob_delete(mob/living/carbon/M)
-	if(cached_purity < 0.95)//Only permanent if you're a good chemist.
+	if(creation_purity < 0.95)//Only permanent if you're a good chemist.
 		nT = M.getorganslot(ORGAN_SLOT_TONGUE)
 		nT.Remove()
 		qdel(nT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives Furranium a base purity of 90% and fixes the tongue restoration code.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Tannhauser Roleplay Experience

Makes it take some chemistry skill to give people permanent fluffy tongues.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Furranium has a base purity of 90%, giving people permanent fluff now requires good chemistry
fix: Fluffy tongues can now properly be temporary
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
