### PR TITLE
Add REAGENT_SYNTHETIC to owo chems

### DIFF
--- a/modular_tannhauser/modules/CitOwOChems/code/chemistry/reagents/OwO.dm
+++ b/modular_tannhauser/modules/CitOwOChems/code/chemistry/reagents/OwO.dm
@@ -6,6 +6,7 @@
 	taste_description	= "affection and love!"
 	inverse_chem_val 		= 0.25		// If the impurity is below 0.5, replace ALL of the chem with inverse_chemupon metabolising
 	var/cached_purity		= 1
+	process_flags = REAGENT_ORGANIC | REAGENT_SYNTHETIC
 
 
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds REAGENT_SYNTHETIC to the base owo chem, so furranium (and plushmium, if it gets a metabolize effect) can affect synthetics.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Skyrat Roleplay Experience
Synths are no longer unfairly immune to the owo virus.
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: OwO chems can now be metabolized by synthetics.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
