### PR TITLE
Orderable Red Pandas

### DIFF
--- a/modular_tannhauser/modules/Bestiary/code/panda.dm
+++ b/modular_tannhauser/modules/Bestiary/code/panda.dm
@@ -30,3 +30,17 @@
 	icon_living = "zest_panda"
 	icon_dead = "blue_dead_panda"
 	gender = MALE
+
+/datum/supply_pack/critter/redpanda
+	name = "Red Panda Crate"
+	desc = "Also known as the lesser panda, but don't tell it that or you'll hurt its feelings."
+	cost = CARGO_CRATE_VALUE * 10
+	contains = list(/mob/living/simple_animal/pet/redpanda)
+	crate_name = "red panda crate"
+
+/datum/supply_pack/critter/redpanda/generate()
+	. = ..()
+	if(prob(1))
+		var/mob/living/simple_animal/pet/redpanda/D = locate() in .
+		qdel(D)
+		new /mob/living/simple_animal/pet/redpanda/zesty(.)

--- a/modular_tannhauser/modules/Bestiary/code/panda.dm
+++ b/modular_tannhauser/modules/Bestiary/code/panda.dm
@@ -40,7 +40,7 @@
 
 /datum/supply_pack/critter/redpanda/generate()
 	. = ..()
-	if(prob(1))
+	if(prob(3))
 		var/mob/living/simple_animal/pet/redpanda/D = locate() in .
 		qdel(D)
 		new /mob/living/simple_animal/pet/redpanda/zesty(.)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes red pandas orderable from supply, with a one percent chance of getting a shiny blue panda. They're priced the same as other orderable pets.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Tannhauser Roleplay Experience
Provides a way to get red pandas that doesn't require gold slimes, chemical life, or admin shenanigans. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Red pandas are now orderable from cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
