### PR TITLE
Random plushie fixes

### DIFF
--- a/modular_tannhauser/modules/CitOwOChems/code/chemistry/reagents/furrrrrr.dm
+++ b/modular_tannhauser/modules/CitOwOChems/code/chemistry/reagents/furrrrrr.dm
@@ -21,18 +21,17 @@
 
 /datum/reagent/OwO/furranium/expose_mob(mob/living/carbon/human/M, method=INJECT, reac_volume)
 	if(method == INJECT)
-		var/turf/T = get_turf(M)
 		M.adjustOxyLoss(reac_volume)
-		//M.DefaultCombatKnockdown(50)
-		if(reac_volume >= 10)
-			M.Stun(reac_volume * 0.25)
 		M.emote("cough")
-		var/obj/item/toy/plush/P = pick(subtypesof(/obj/item/toy/plush))
-		new P(T)
-		M.visible_message("<span class='warning'>[M] suddenly coughs up a [P.name]!</b></span>",\
-						"<span class='warning'>You feel a lump form in your throat, as you suddenly cough up what seems to be a hairball?</b></span>")
-		var/T2 = get_random_station_turf()
-		P.throw_at(T2, 8, 1)
+		//M.DefaultCombatKnockdown(50)
+		if(reac_volume >= 15)
+			M.Stun(reac_volume * 0.25)
+			var/obj/item/toy/plush/PType = pick(GLOB.valid_plushie_paths)
+			var/obj/item/toy/plush/P = new PType(get_turf(M))
+			M.visible_message("<span class='warning'>[M] suddenly coughs up a [P.name]!</b></span>",\
+							"<span class='warning'>You feel a lump form in your throat, as you suddenly cough up what seems to be a hairball?</b></span>")
+			var/T2 = get_random_station_turf()
+			P.throw_at(T2, 8, 1)
 	..()
 
 /datum/reagent/OwO/furranium/on_mob_life(mob/living/carbon/M)

--- a/modular_tannhauser/modules/CitOwOChems/code/chemistry/recipes/OwOCookBook.dm
+++ b/modular_tannhauser/modules/CitOwOChems/code/chemistry/recipes/OwOCookBook.dm
@@ -124,13 +124,14 @@
 	if(plushmium.purity > 0.9)
 		return
 	if(react_vol < 20) //It creates a normal plush at low volume.. at higher amounts, things get slightly more interesting.
-		new /obj/item/toy/plush/random(get_turf(holder.my_atom))
+		var/obj/item/toy/plush/P = pick(GLOB.valid_plushie_paths)
+		new P(get_turf(holder.my_atom))
 	else
 		new /obj/item/toy/plush/plushling(get_turf(holder.my_atom))
 	holder.my_atom.audible_message("<span class='warning'>The reaction suddenly zaps, creating a plushie!</b></span>")
 	clear_products(holder)
 
-
+/*
 /datum/chemical_reaction/OwO/plushmium/OwOExplode(datum/reagents, var/atom/my_atom, volume, temp, ph)
 	if(volume < 20) //It creates a normal plush at low volume.. at higher amounts, things get slightly more interesting.
 		new /obj/item/toy/plush/random(get_turf(my_atom))
@@ -138,3 +139,4 @@
 		new /obj/item/toy/plush/plushling(get_turf(my_atom))
 	my_atom.visible_message("<span class='warning'>The reaction suddenly zaps, creating a plushie!</b></span>")
 	my_atom.reagents.clear_reagents()
+*/

--- a/modular_tannhauser/modules/CitOwOChems/code/obj/plushies.dm
+++ b/modular_tannhauser/modules/CitOwOChems/code/obj/plushies.dm
@@ -1,5 +1,9 @@
 /obj/item/toy/plush
 	var/can_random_spawn = TRUE			//if this is FALSE, don't spawn this for random plushies.
+	
+/obj/item/toy/plush/carpplushie/dehy_carp
+	can_random_spawn = FALSE
+
 //	var/snowflake_idvar/snowflake_id
 
 
@@ -11,7 +15,7 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 		if(!initial(abstract.can_random_spawn))
 			continue
 		. += i
-
+/*
 /obj/item/toy/plush/random
 	name = "Illegal plushie"
 	desc = "Something fucked up"
@@ -29,12 +33,13 @@ GLOBAL_LIST_INIT(valid_plushie_paths, valid_plushie_paths())
 
 	new newtype(loc)
 	return INITIALIZE_HINT_QDEL
-
+*/
 /obj/item/toy/plush/plushling
 	icon = 'modular_skyrat/master_files/icons/obj/plushes.dmi'
 	icon_state = "blue_fox"
 	name = "peculiar plushie"
 	desc = "An adorable stuffed toy- wait, did it just move?"
+	can_random_spawn = FALSE
 	var/absorb_cooldown = 100 //ticks cooldown between absorbs
 	var/next_absorb = 0 //When can it absorb another plushie
 	var/check_interval = 20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the /obj/item/toy/plush/random.
Added dehydrated carp and plushlings to the random plushie blacklist.
Refactored furranium so that plushie vomit properly launches the plushie, and integrated it as part of the stun.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Tannhauser Roleplay Experience
plush/random couldn't be interacted with via code after being created, since it created a new instance then deleted itself. It has been commented out.
Dehydrated carp and plushlings do more than sit around and be adorable, so they've been removed from the random plushie GLOBAL list.
Refactoring the code to remove plush/random fixed furranium's plushie vomit so the plushies spawned would properly launch in random directions.
Adjusted furranium so that the threshold for the plushie vomit was the same as the threshold for the stun, and increased it to require a full syringe - if you want to make plushies using chemicals, you really should be using plushmium.

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: furranium now requires a full syringe to stun and spawn plushies
fix: furranium plushies are now properly vomited out at high speeds
refactor: refactored code for random plushies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
