### PR TITLE
Plushmium updates

### DIFF
--- a/modular_tannhauser/modules/CitOwOChems/code/mob/plushie.dm
+++ b/modular_tannhauser/modules/CitOwOChems/code/mob/plushie.dm
@@ -39,6 +39,7 @@
 	pressure_resistance = 200
 
 /mob/living/simple_animal/pet/plushie/Initialize()
+	AddElement(/datum/element/pet_bonus, "squeaks!")
 	. = ..()
 //	AddElement(/datum/element/mob_holder, "plushie")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives the living plushie custom response messages
Let's you scoop up and hold living plushies
Petting living plushies give the animal pet mood buff
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The Tannhauser Roleplay Experience
You now pet living plushies, instead of poking them; attacking has you rip them apart
Normal plushes can be held, so may as well let living plushies be held too
Plushies are soft and cute, so petting them gives mood buff
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Living plushies can now be pet and held
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
