### PR TITLE
Tourist station fixes

### DIFF
--- a/_maps/map_files/AlphaStation/AlphaStation_lower.dmm
+++ b/_maps/map_files/AlphaStation/AlphaStation_lower.dmm
@@ -3609,7 +3609,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/pinpointer/shuttle,
 /turf/open/floor/iron,
 /area/station/security/warden)
 "dyk" = (
@@ -17744,6 +17743,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/item/pinpointer/crew,
 /turf/open/floor/iron,
 /area/station/security/warden)
 "qNR" = (

--- a/_maps/map_files/AlphaStation/AlphaStation_lower.dmm
+++ b/_maps/map_files/AlphaStation/AlphaStation_lower.dmm
@@ -7017,7 +7017,7 @@
 	dir = 4
 	},
 /obj/item/food/monkeycube/gorilla{
-	desc = "A Waffle Co. brand gorilla bouillon cube. Now with extra molecules!";
+	desc = "A Honk Co. brand gorilla bouillon cube. Now with an extra punch!";
 	name = "gorilla bouillon cube";
 	pixel_x = 6
 	},

--- a/_maps/map_files/AlphaStation/AlphaStation_lower.dmm
+++ b/_maps/map_files/AlphaStation/AlphaStation_lower.dmm
@@ -7462,13 +7462,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
-"hou" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/antinoblium,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "hox" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #2";
@@ -59020,7 +59013,7 @@ lot
 oFI
 xuz
 cNO
-hou
+iHT
 iHT
 dzn
 irR

--- a/_maps/map_files/AlphaStation/AlphaStation_upper.dmm
+++ b/_maps/map_files/AlphaStation/AlphaStation_upper.dmm
@@ -8393,8 +8393,7 @@
 	dir = 1;
 	icon_state = "rightsecure";
 	name = "Head of Personnel's Desk";
-	req_access = list("hop");
-	req_access_txt = "57"
+	req_access = list("hop")
 	},
 /obj/machinery/door/firedoor{
 	name = "Emergency Shutter"
@@ -9062,7 +9061,8 @@
 "ful" = (
 /obj/structure/table/wood,
 /obj/machinery/button/ticket_machine{
-	pixel_x = 32
+	pixel_x = 32;
+	req_access = list("hop")
 	},
 /obj/item/paper_bin/carbon{
 	pixel_x = -2;
@@ -9080,14 +9080,14 @@
 	id = "hop";
 	name = "Privacy Shutters Control";
 	pixel_x = -6;
-	req_access_txt = "57"
+	req_access = list("hop")
 	},
 /obj/machinery/button/door/directional/south{
 	id = "hopqueue";
 	name = "Queue Shutters Control";
 	pixel_x = -6;
 	pixel_y = -34;
-	req_access_txt = "57"
+	req_access = list("hop")
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -12360,13 +12360,6 @@
 	},
 /turf/open/floor/iron/dark/purple,
 /area/station/science/research)
-"hgc" = (
-/obj/structure/table/wood,
-/obj/structure/window/reinforced/spawner/east,
-/obj/structure/window/reinforced/spawner/north,
-/obj/item/storage/toolbox/emergency/turret/mesa,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "hgp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -40243,6 +40236,13 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/hos)
+"xsx" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
+/obj/item/storage/toolbox/emergency/turret/mesa,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "xsy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -66517,7 +66517,7 @@ gll
 gll
 qBF
 oKo
-hgc
+xsx
 bxj
 reu
 kts

--- a/_maps/map_files/AlphaStation/AlphaStation_upper.dmm
+++ b/_maps/map_files/AlphaStation/AlphaStation_upper.dmm
@@ -1652,6 +1652,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/pinpointer/crew,
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/hos)
 "aXt" = (
@@ -12359,6 +12360,13 @@
 	},
 /turf/open/floor/iron/dark/purple,
 /area/station/science/research)
+"hgc" = (
+/obj/structure/table/wood,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/window/reinforced/spawner/north,
+/obj/item/storage/toolbox/emergency/turret/mesa,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "hgp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -24628,12 +24636,9 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "oqx" = (
-/obj/item/orion_ship{
-	desc = "A model Orca Class drop ship, A comander fingure is stuck in it and it even has a miniature FX-293 reactor, which was renowned for its instability and tendency to explode...";
-	name = "model drop ship"
-	},
 /obj/structure/displaycase,
 /obj/structure/cable,
+/obj/item/storage/toolbox/fishing,
 /turf/open/floor/carpet/executive,
 /area/station/command/corporate_showroom)
 "orz" = (
@@ -66512,7 +66517,7 @@ gll
 gll
 qBF
 oKo
-kts
+hgc
 bxj
 reu
 kts


### PR DESCRIPTION
Minor fixes to the station

- Took away the "bomb" out of the show room due to labels not being read.
- Swapped out pin pointer in the warden office for the correct item
- Keeping the "gorilla bouillon cube" in kitchen, just updating its warning label "A Honk Co. brand gorilla bouillon cube. Now with an extra punch!"
- Fixed HOP shutter access