### PR TITLE
Removes the armageddon coronial mass ejection

### DIFF
--- a/modular_skyrat/modules/cme/code/_cme_defines.dm
+++ b/modular_skyrat/modules/cme/code/_cme_defines.dm
@@ -14,7 +14,6 @@ GLOBAL_LIST_INIT(cme_loot_list, list(
 #define CME_MINIMAL "minimal"
 #define CME_MODERATE "moderate"
 #define CME_EXTREME "extreme"
-#define CME_ARMAGEDDON "armageddon"
 
 //Times are SECONDS, they're devided by 2 because that's how long the controller takes to process. 20 deciseconds = 2 seconds. I know, it's dumb as fuck.
 //NOT ANYMORE, NOW WE MULTIPLY BY A HALF
@@ -52,14 +51,3 @@ GLOBAL_LIST_INIT(cme_loot_list, list(
 #define CME_EXTREME_START_LOWER 60 * 0.5
 #define CME_EXTREME_START_UPPER 120 * 0.5
 #define CME_EXTREME_END 120 * 0.5
-
-#define CME_ARMAGEDDON_LIGHT_RANGE_LOWER 25
-#define CME_ARMAGEDDON_LIGHT_RANGE_UPPER 30
-#define CME_ARMAGEDDON_HEAVY_RANGE_LOWER 20
-#define CME_ARMAGEDDON_HEAVY_RANGE_UPPER 25
-#define CME_ARMAGEDDON_FREQUENCY_LOWER 5 * 0.5
-#define CME_ARMAGEDDON_FREQUENCY_UPPER 7 * 0.5
-#define CME_ARMAGEDDON_BUBBLE_BURST_TIME 10 SECONDS
-#define CME_ARMAGEDDON_START_LOWER 60 * 0.5
-#define CME_ARMAGEDDON_START_UPPER 70 * 0.5
-#define CME_ARMAGEDDON_END 300 * 0.5

--- a/modular_skyrat/modules/cme/code/cme.dm
+++ b/modular_skyrat/modules/cme/code/cme.dm
@@ -6,10 +6,10 @@
 /* Welcome to the CME control system.
 *
 *	This controls the CME event, or coronal mass ejection event, which causes multiple EMP bubbles to form around the station
-*	depending on conditons and time. There are currently 4 settings of CME, all of which have settings defined in the
+*	depending on conditons and time. There are currently 3 settings of CME, all of which have settings defined in the
 *	cme defines DM file. See that for more info
 *
-*	Armageddon is truly going to fuck the station, use it sparingly.
+*	Armageddon has been removed due to admin abuse, a sad day
 */
 
 /datum/round_event_control/cme
@@ -65,15 +65,6 @@
 /datum/round_event/cme/extreme
 	cme_intensity = CME_EXTREME
 
-/datum/round_event_control/cme/armageddon
-	name = "Coronal Mass Ejection: Armageddon"
-	typepath = /datum/round_event/cme/armageddon
-	weight = 0
-	max_occurrences = 0
-
-/datum/round_event/cme/armageddon
-	cme_intensity = CME_ARMAGEDDON
-
 /datum/round_event/cme/setup()
 	if(!cme_intensity)
 		cme_intensity = pick(CME_MINIMAL, CME_UNKNOWN, CME_MODERATE, CME_EXTREME)
@@ -98,11 +89,6 @@
 			cme_frequency_upper = CME_EXTREME_FREQUENCY_UPPER
 			start_when = rand(CME_EXTREME_START_LOWER, CME_EXTREME_START_UPPER)
 			end_when = start_when + CME_EXTREME_END
-		if(CME_ARMAGEDDON)
-			cme_frequency_lower = CME_ARMAGEDDON_FREQUENCY_LOWER
-			cme_frequency_upper = CME_ARMAGEDDON_FREQUENCY_UPPER
-			start_when = rand(CME_ARMAGEDDON_START_LOWER, CME_ARMAGEDDON_START_UPPER)
-			end_when = start_when + CME_ARMAGEDDON_END
 		else
 			message_admins("CME setup failure, aborting.")
 			kill()
@@ -136,10 +122,6 @@
 				priority_announce("Critical Coronal mass ejection detected! Expected intensity: [uppertext(cme_intensity)]. Impact in: [round((start_when * SSevents.wait) * 0.1, 0.1)] seconds. \
 				All synthetic and non-organic lifeforms should seek shelter immediately! \
 				Neutralize magnetic field bubbles at all costs.", "Solar Event", sound('modular_skyrat/modules/cme/sound/cme_warning.ogg'))
-			if(CME_ARMAGEDDON)
-				SSsecurity_level.set_level(SEC_LEVEL_GAMMA)
-				priority_announce("Neutron Mass Ejection Detected! Expected intensity: [uppertext(cme_intensity)]. Impact in: [round((start_when * SSevents.wait) * 0.1, 0.1)] seconds. \
-				All personnel should proceed to their nearest warpgate for evacuation, the Solar Federation has issued this mandatory alert.", "Solar Event", sound('modular_skyrat/modules/cme/sound/cme_warning.ogg'))
 
 /datum/round_event/cme/tick()
 	if(ISMULTIPLE(activeFor, rand(cme_frequency_lower, cme_frequency_upper)))
@@ -161,10 +143,6 @@
 		if(CME_EXTREME)
 			var/obj/effect/cme/extreme/spawnedcme = new(spawnpoint)
 			announce_to_ghosts(spawnedcme)
-		if(CME_ARMAGEDDON)
-			var/obj/effect/cme/armageddon/spawnedcme = new(spawnpoint)
-			announce_to_ghosts(spawnedcme)
-
 
 /datum/round_event/cme/end()
 	minor_announce("The station has cleared the solar flare, please proceed to repair electronic failures.", "CME cleared:")
@@ -217,16 +195,6 @@
 	cme_heavy_range_lower = CME_EXTREME_HEAVY_RANGE_LOWER
 	cme_heavy_range_upper = CME_EXTREME_HEAVY_RANGE_UPPER
 
-/obj/effect/cme/armageddon
-	name = "ARMAGEDDON SOLAR EJECTION"
-	color = COLOR_VIOLET
-	light_color = COLOR_VIOLET
-	timeleft = CME_ARMAGEDDON_BUBBLE_BURST_TIME
-	cme_light_range_lower = CME_ARMAGEDDON_LIGHT_RANGE_LOWER
-	cme_light_range_upper = CME_ARMAGEDDON_LIGHT_RANGE_UPPER
-	cme_heavy_range_lower = CME_ARMAGEDDON_HEAVY_RANGE_LOWER
-	cme_heavy_range_upper = CME_ARMAGEDDON_HEAVY_RANGE_UPPER
-
 /obj/effect/cme/Initialize(mapload)
 	. = ..()
 	playsound(src,'sound/weapons/resonator_fire.ogg',75,TRUE)
@@ -249,20 +217,6 @@
 	playsound(src,'modular_skyrat/modules/cme/sound/cme.ogg', 100)
 	qdel(src)
 
-/obj/effect/cme/armageddon/burst()
-	if(neutralized)
-		visible_message(span_notice("[src] fizzles out into nothingness."))
-		new /obj/effect/particle_effect/fluid/smoke/bad(loc)
-		qdel(src)
-		return
-	var/pulse_range_light = rand(cme_light_range_lower, cme_light_range_upper)
-	var/pulse_range_heavy = rand(cme_heavy_range_lower, cme_heavy_range_upper)
-	empulse(src, pulse_range_heavy, pulse_range_light)
-	explosion(src, 0, 3, 10, flame_range = 10)
-	playsound(src,'sound/weapons/resonator_blast.ogg',100,TRUE)
-	playsound(src,'modular_skyrat/modules/cme/sound/cme.ogg', 100)
-	qdel(src)
-
 /obj/effect/cme/singularity_pull()
 	burst()
 
@@ -281,18 +235,6 @@
 	var/turf/open/T = get_turf(src)
 	if(istype(T))
 		T.atmos_spawn_air("o2=30;plasma=30;TEMP=5778")
-	color = COLOR_WHITE
-	light_color = COLOR_WHITE
-	neutralized = TRUE
-	var/atom/movable/loot = pick_weight(GLOB.cme_loot_list)
-	new loot(loc)
-
-/obj/effect/cme/armageddon/anomalyNeutralize()
-	playsound(src,'sound/weapons/resonator_blast.ogg',100,TRUE)
-	new /obj/effect/particle_effect/fluid/smoke/bad(loc)
-	var/turf/open/T = get_turf(src)
-	if(istype(T))
-		T.atmos_spawn_air("o2=30;plasma=80;TEMP=5778")
 	color = COLOR_WHITE
 	light_color = COLOR_WHITE
 	neutralized = TRUE


### PR DESCRIPTION

## About The Pull Request

Removes the coronial mass ejection's armageddon intensity setting, it was abused and lead to the server slowing down and crying out in pain multiple times. Not very enjoyable

## How This Contributes To Tannhauser

Players can finally not worry about admin-spawned armageddon CME's, for high amounts of admin abuse please use the much more tame "extreme" variant

## Changelog
:cl:
del: Removed armageddon CME's
/:cl:
