### PR TITLE
Events update. Meteor Fix

### DIFF
--- a/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
+++ b/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
@@ -52,15 +52,15 @@
 /datum/round_event_control/preset/moderate
 	name = "Highly Disruptive Random Event"
 	max_occurrences = 10
-	earliest_start = 10 MINUTES
+	earliest_start = 30 MINUTES
 	selectable_chaos_level = EVENT_CHAOS_MED
 
 /datum/round_event_control/preset/high
 	name = "Catastrophic Random Event"
 	max_occurrences = 10
-	earliest_start = 30 MINUTES
+	earliest_start = 50 MINUTES
 	selectable_chaos_level = EVENT_CHAOS_HIGH
-	min_players = 70
+	min_players = 20
 
 /**
  * EVENT CHAOS DECLARES
@@ -99,7 +99,7 @@
 	chaos_level = EVENT_CHAOS_LOW
 
 /datum/round_event_control/grey_tide
-	chaos_level = EVENT_CHAOS_LOW
+	chaos_level = EVENT_CHAOS_MED
 
 /datum/round_event_control/processor_overload
 	chaos_level = EVENT_CHAOS_LOW
@@ -170,10 +170,10 @@
 	chaos_level = EVENT_CHAOS_MED
 
 /datum/round_event_control/meteor_wave/threatening
-	chaos_level = EVENT_CHAOS_MED
+	chaos_level = EVENT_CHAOS_HIGH
 
 /datum/round_event_control/meteor_wave
-	chaos_level = EVENT_CHAOS_MED
+	chaos_level = EVENT_CHAOS_HIGH
 
 /datum/round_event_control/immovable_rod
 	chaos_level = EVENT_CHAOS_MED

--- a/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
+++ b/modular_skyrat/modules/event_vote/code/event_chaos_system.dm
@@ -52,15 +52,15 @@
 /datum/round_event_control/preset/moderate
 	name = "Highly Disruptive Random Event"
 	max_occurrences = 10
-	earliest_start = 30 MINUTES
+	earliest_start = 10 MINUTES
 	selectable_chaos_level = EVENT_CHAOS_MED
 
 /datum/round_event_control/preset/high
 	name = "Catastrophic Random Event"
 	max_occurrences = 10
-	earliest_start = 50 MINUTES
+	earliest_start = 30 MINUTES
 	selectable_chaos_level = EVENT_CHAOS_HIGH
-	min_players = 20
+	min_players = 70
 
 /**
  * EVENT CHAOS DECLARES
@@ -99,7 +99,7 @@
 	chaos_level = EVENT_CHAOS_LOW
 
 /datum/round_event_control/grey_tide
-	chaos_level = EVENT_CHAOS_MED
+	chaos_level = EVENT_CHAOS_LOW
 
 /datum/round_event_control/processor_overload
 	chaos_level = EVENT_CHAOS_LOW
@@ -170,10 +170,10 @@
 	chaos_level = EVENT_CHAOS_MED
 
 /datum/round_event_control/meteor_wave/threatening
-	chaos_level = EVENT_CHAOS_HIGH
+	chaos_level = EVENT_CHAOS_MED
 
 /datum/round_event_control/meteor_wave
-	chaos_level = EVENT_CHAOS_HIGH
+	chaos_level = EVENT_CHAOS_MED
 
 /datum/round_event_control/immovable_rod
 	chaos_level = EVENT_CHAOS_MED

--- a/modular_tannhauser/_skyrat_override/modules/event_vote/code/event_chaos_system.dm
+++ b/modular_tannhauser/_skyrat_override/modules/event_vote/code/event_chaos_system.dm
@@ -1,0 +1,23 @@
+/// Tanhauser Override file for skyrat based event system
+
+
+/// Increases the minimum time for moderately disruptive events
+/datum/round_event_control/preset/moderate
+	earliest_start = 30 MINUTES
+
+/// Lowersa player count for highly disruptive events and increases the minimum time before they occur
+/datum/round_event_control/preset/high
+	earliest_start = 50 MINUTES
+	min_players = 20
+
+/// Changes Grey Tide to medium severity to cope with lack of AI support
+/datum/round_event_control/grey_tide
+	chaos_level = EVENT_CHAOS_MED
+
+
+/// Meteors escalated in severity
+/datum/round_event_control/meteor_wave/threatening
+	chaos_level = EVENT_CHAOS_HIGH
+
+/datum/round_event_control/meteor_wave
+	chaos_level = EVENT_CHAOS_HIGH

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6369,6 +6369,7 @@
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\spitter.dm"
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\warrior.dm"
 #include "modular_tannhauser\_skyrat_override\modules\DynamicRules\code\dynamics.dm"
+#include "modular_tannhauser\_skyrat_override\modules\event_vote\code\event_chaos_system.dm"
 #include "modular_tannhauser\_skyrat_override\modules\Jobs\vet_crew.dm"
 #include "modular_tannhauser\_skyrat_override\modules\lobby_cam\code\lobby_cam.dm"
 #include "modular_tannhauser\master_files\code\game\th_areas.dm"


### PR DESCRIPTION
**-Changed event control presets for  chaos moderate events and high events to more reasonable values for out server.
 -Meteors now will only trigger at 20+ players and 50 minuets in. (besides meatyores they are the same)**

