### PR TITLE
Removes the "destroy the telecomms hub" objective

### DIFF
--- a/code/modules/antagonists/traitor/objectives/sabotage_machinery.dm
+++ b/code/modules/antagonists/traitor/objectives/sabotage_machinery.dm
@@ -69,7 +69,7 @@ GLOBAL_DATUM_INIT(objective_machine_handler, /datum/objective_target_machine_han
 	progression_maximum = 30 MINUTES
 
 	applicable_jobs = list(
-		JOB_STATION_ENGINEER = /obj/machinery/telecomms/hub,
+		//JOB_STATION_ENGINEER = /obj/machinery/telecomms/hub,
 		JOB_SCIENTIST = /obj/machinery/rnd/server,
 	)
 


### PR DESCRIPTION

## About The Pull Request

Short one, This PR just comments out the telecomms hub so it wont appear in traitor objectives
Requested by Zest

## Changelog

:cl:
del: Removes the telecomms hub objective
/:cl:
