### PR TITLE
Pubby fixes

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -183,6 +183,7 @@
 /area/station/command/heads_quarters/qm)
 "aaL" = (
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "aaM" = (
@@ -2546,8 +2547,10 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/bot_red,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/photocopier,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ajn" = (
@@ -2555,28 +2558,20 @@
 	pixel_y = 32
 	},
 /obj/machinery/light/directional/north,
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
-"ajo" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
-"ajp" = (
-/obj/machinery/photocopier,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
+"ajo" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 8
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
+"ajp" = (
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
@@ -2730,17 +2725,17 @@
 /area/station/security/office)
 "aka" = (
 /obj/machinery/suit_storage_unit/hos,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
-"akb" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /obj/structure/sign/plaques/kiddie{
 	desc = "An embossed piece of paper from the University of Nanotrasen at Portpoint.";
 	name = "\improper 'Diploma' frame";
 	pixel_y = 32
 	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
+"akb" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "akc" = (
@@ -2759,6 +2754,11 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/deputy,
+/obj/machinery/button/door/directional/north{
+	id = "secmechbay";
+	name = "Sec Mech Bay Shutters Control";
+	impact_sound = ssssss
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "ake" = (
@@ -2836,6 +2836,7 @@
 /area/station/maintenance/department/security/brig)
 "aks" = (
 /obj/machinery/light/small/directional/south,
+/mob/living/basic/cockroach/glockroach,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "akt" = (
@@ -2924,6 +2925,7 @@
 	name = "Evidence Closet"
 	},
 /obj/machinery/camera/autoname/directional/east,
+/obj/item/storage/box/donkpockets/donkpocketgondola,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "akM" = (
@@ -2983,6 +2985,7 @@
 /area/station/command/heads_quarters/hos)
 "akW" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "akZ" = (
@@ -3207,6 +3210,7 @@
 "alI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "alJ" = (
@@ -4283,6 +4287,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 6
 	},
+/obj/machinery/requests_console/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "apg" = (
@@ -4740,17 +4745,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ark" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/ammo_workbench,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/range)
+/obj/item/toy/plush/skyrat/derg_plushie,
+/obj/structure/table/wood,
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "arl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7466,6 +7467,7 @@
 /obj/item/flashlight/lamp/green{
 	pixel_x = -9
 	},
+/obj/item/toy/captainsaid/collector,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "aAy" = (
@@ -17095,6 +17097,7 @@
 "biq" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/purple,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bir" = (
@@ -20021,6 +20024,9 @@
 	},
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 1
+	},
+/obj/item/reagent_containers/cup/glass/coffee/colonial{
+	pixel_x = 8
 	},
 /turf/open/floor/carpet/neon/simple/black/nodots,
 /area/station/bitrunning/den)
@@ -23043,6 +23049,7 @@
 /turf/open/floor/plating,
 /area/station/medical/surgery)
 "bFP" = (
+/mob/living/simple_animal/bot/cleanbot/autopatrol,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "bFS" = (
@@ -23180,14 +23187,8 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/dock)
 "bGG" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	name = "Outlet Injector"
-	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/station/service/chapel/dock)
 "bGH" = (
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -23346,20 +23347,16 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/dock)
 "bHL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/service/chapel/dock)
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "bHM" = (
 /turf/closed/wall/r_wall,
 /area/station/service/chapel/dock)
 "bHN" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west{
-	layer = 2.9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/iron,
+/area/station/service/chapel/dock)
 "bHP" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark,
@@ -23754,6 +23751,7 @@
 /area/space/nearstation)
 "bKa" = (
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "bKc" = (
@@ -23765,6 +23763,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "bKe" = (
@@ -26742,6 +26741,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/item/toy/plush/skyrat/engihound,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "bUW" = (
@@ -33847,16 +33847,12 @@
 "cUr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/requests_console{
-	department = "Security";
-	pixel_x = 30
-	},
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "cVo" = (
@@ -35200,6 +35196,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/cytology)
+"edu" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "edJ" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/iron/white,
@@ -35897,12 +35897,21 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "eIr" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/machinery/button/door/directional/north{
+	id = "secmechbay";
+	name = "Sec Mech Bay Shutters Control";
+	impact_sound = ssssss
+	},
 /obj/machinery/door/poddoor/shutters{
-	id = "jangarage";
-	name = "Custodial Closet Shutters"
+	id = "secmechbay";
+	name = "Sec Mech Bay"
 	},
 /turf/open/floor/iron/dark,
-/area/station/hallway/secondary/construction)
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "eIL" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -36641,6 +36650,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/dorms/barracks)
+"fkV" = (
+/obj/structure/training_machine,
+/obj/effect/turf_decal/trimline/yellow,
+/obj/item/target/clown,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "fkX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -37626,16 +37641,25 @@
 /turf/open/floor/carpet,
 /area/station/service/chapel)
 "fVq" = (
-/obj/structure/cable,
-/obj/machinery/computer,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "fVT" = (
 /obj/machinery/computer/security/telescreen/ordnance{
 	dir = 1;
 	pixel_y = -30
 	},
 /obj/structure/chair/office/light,
+/obj/item/toy/plush/skyrat/igneous_synth{
+	desc = "Stinky Synth Snoodl!";
+	name = "Dalton Snoodle"
+	},
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "fVY" = (
@@ -38126,8 +38150,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "glZ" = (
-/turf/closed/wall,
-/area/station/hallway/secondary/construction)
+/obj/machinery/door/airlock/security{
+	name = "Security Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/turf_decal/delivery/blue,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "gma" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
@@ -38144,6 +38176,7 @@
 /obj/item/radio/intercom{
 	pixel_x = -28
 	},
+/mob/living/basic/garden_gnome,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "gmN" = (
@@ -39036,6 +39069,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"gVI" = (
+/obj/structure/cable,
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/red,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "gVP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39558,7 +39601,9 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "hpY" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39682,6 +39727,13 @@
 /obj/structure/flora/bush/leavy/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central/fore)
+"hvt" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/chapel/dock)
 "hvF" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/bot,
@@ -39848,6 +39900,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "hBR" = (
@@ -40625,6 +40680,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
+"ico" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "icp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -41087,14 +41151,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ixW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "ixY" = (
 /obj/structure/sink/directional/west,
 /obj/structure/cable,
@@ -41774,6 +41833,11 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"iZK" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "jaC" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -41981,6 +42045,9 @@
 "jiQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
@@ -42773,8 +42840,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "jOv" = (
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/machinery/modular_computer/preset/civilian,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "jOw" = (
@@ -42793,6 +42860,9 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"jPb" = (
+/turf/open/space/basic,
+/area/station/command/bridge)
 "jPf" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -43320,11 +43390,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "kpN" = (
-/obj/structure/training_machine,
-/obj/item/target/syndicate,
-/obj/effect/turf_decal/trimline/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
-/area/station/security/range)
+/area/station/security/office)
 "kpW" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable,
@@ -43844,7 +43916,17 @@
 /area/station/security/prison)
 "kHO" = (
 /obj/structure/bed/dogbed/renault,
-/mob/living/basic/pet/fox/renault,
+/mob/living/basic/pet/fox/renault{
+	icon_dead = "blue_dead_panda"s";
+	icon_living = "zest_panda";
+	icon_state = "zest_panda";
+	icon = 'modular_tannhauser/modules/Bestiary/art/mob/red_panda.dmi';
+	gender = "male";
+	light_color = "#00FF00";
+	light_range = 2;
+	speak_emote = list("chirps","huff-quacks")s);
+	name = "Zesty"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain/private)
 "kHP" = (
@@ -44577,6 +44659,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"lls" = (
+/obj/item/virgin_mary,
+/turf/closed/wall,
+/area/station/service/chapel/monastery)
 "llP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -44975,8 +45061,14 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms/barracks)
 "lBt" = (
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "lBG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/glass/reinforced,
@@ -45856,6 +45948,12 @@
 "mkM" = (
 /turf/closed/wall,
 /area/station/medical/abandoned)
+"mlD" = (
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/landmark/secequipment,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "mlP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -46428,14 +46526,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "mDL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/open/floor/iron/dark,
-/area/station/security/range)
+/turf/open/floor/plating,
+/area/space/nearstation)
 "mDW" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -46488,6 +46580,10 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"mGR" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "mHy" = (
 /obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
 /turf/open/floor/wood,
@@ -47439,9 +47535,9 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
 "nwz" = (
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/security/armory)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/station/service/chapel/dock)
 "nwH" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Atmospherics Tank - Toxins";
@@ -47493,7 +47589,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 5
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
@@ -47501,12 +47597,20 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "nAS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/ammo_workbench,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/entry)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "nBt" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -48841,6 +48945,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"owq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "owx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49646,13 +49758,35 @@
 	},
 /turf/closed/wall,
 /area/station/cargo/storage)
+"oYy" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
+"oYJ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/structure/table/rolling,
+/obj/item/toy/plush/skyrat/engihound,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "oYQ" = (
 /obj/machinery/door/poddoor/shutters{
-	id = "jangarage";
-	name = "Custodial Closet Shutters"
+	id = "secmechbay";
+	name = "Sec Mech Bay"
 	},
 /turf/open/floor/iron/dark,
-/area/station/hallway/secondary/construction)
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "oZv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -49721,6 +49855,7 @@
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 8
 	},
+/mob/living/basic/pet/bumbles,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "pbR" = (
@@ -49763,6 +49898,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
+"peh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "peY" = (
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50071,8 +50220,12 @@
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "prm" = (
-/turf/open/floor/wood/cold,
-/area/station/hallway/secondary/construction)
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "prr" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -50188,9 +50341,16 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pxb" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "pxO" = (
 /obj/item/transfer_valve{
 	pixel_x = -5
@@ -50474,6 +50634,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"pFV" = (
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "pGi" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -50586,6 +50752,12 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"pKg" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "pKx" = (
 /obj/structure/closet/crate/secure/weapon{
 	desc = "A secure clothing crate.";
@@ -50674,6 +50846,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"pMv" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel"
+	},
+/turf/open/floor/iron,
+/area/station/service/chapel/dock)
 "pMI" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -50988,6 +51166,7 @@
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/neon/simple/black/nodots,
 /area/station/bitrunning/den)
 "pXT" = (
@@ -51106,9 +51285,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "qbK" = (
-/obj/structure/table_frame,
-/turf/open/floor/wood/cold,
-/area/station/hallway/secondary/construction)
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "qbZ" = (
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -51178,6 +51362,7 @@
 	pixel_x = -24;
 	pixel_y = 27
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "qfC" = (
@@ -51215,8 +51400,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qgK" = (
-/turf/closed/wall/r_wall,
-/area/station/hallway/secondary/construction)
+/obj/structure/cable,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron/recharge_floor,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "qgM" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
@@ -52430,6 +52619,14 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"rbm" = (
+/obj/structure/cable,
+/obj/machinery/computer/mech_bay_power_console,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/red,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "rbo" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -52463,14 +52660,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "rcV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/hos)
 "rdn" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/engineering_welding,
@@ -52734,6 +52927,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet/restrooms)
+"rmN" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/landmark/secequipment,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "rmW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -52919,6 +53118,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
+"rtb" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "rtd" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -53007,6 +53218,10 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"rvi" = (
+/obj/item/toy/plush/skyrat/plushie_dan,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "rvH" = (
 /obj/machinery/shower/directional/south,
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -53112,6 +53327,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"rya" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ryi" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -53451,9 +53670,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/corner{
-	dir = 4
-	},
 /obj/item/reagent_containers/cup/glass/bottle/whiskey{
 	pixel_x = -9;
 	pixel_y = 1
@@ -53664,6 +53880,7 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "rTD" = (
@@ -53823,6 +54040,9 @@
 "sbr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
@@ -55101,9 +55321,6 @@
 "tbD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
@@ -55919,11 +56136,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "tIf" = (
-/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
-	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "tIl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57252,9 +57472,8 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "uDp" = (
-/obj/item/toy/plush/skyrat/igneous_synth{
-	desc = "Stinky Synth Snoodl!";
-	name = "Dalton Snoodle"
+/obj/item/toy/plush/moth{
+	name = "Wereni Moff"
 	},
 /turf/open/misc/asteroid/airless,
 /area/station/science/ordnance/bomb)
@@ -57390,6 +57609,13 @@
 /obj/effect/landmark/start/psychologist,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
+"uLC" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "uLF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
@@ -57449,10 +57675,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "uMv" = (
-/obj/structure/cable,
-/obj/structure/table_frame,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "uMY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -57469,9 +57698,27 @@
 /turf/open/floor/wood,
 /area/station/security/prison)
 "uNz" = (
-/obj/structure/table_frame,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/obj/structure/table,
+/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
+	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob";
+	pixel_y = 9;
+	pixel_x = -10
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 12
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "uOA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -57681,6 +57928,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
+"uXC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 5
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "uXE" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
@@ -58599,6 +58855,11 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"vBh" = (
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "vBp" = (
 /obj/item/stack/pipe_cleaner_coil,
 /obj/structure/disposalpipe/segment{
@@ -59164,15 +59425,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "waf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	name = "Equipment Room"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/delivery/blue,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "way" = (
@@ -60901,6 +61159,12 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"xkU" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "xlf" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -62006,6 +62270,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"xYY" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/obj/machinery/mechpad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "xZV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -74846,7 +75120,7 @@ kcx
 cfN
 cfN
 cfN
-bWV
+lls
 bXJ
 cve
 cuK
@@ -75581,7 +75855,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+maV
 aaa
 aaa
 aaa
@@ -76612,7 +76886,7 @@ aaa
 aaa
 aaa
 aaa
-emV
+mDL
 bGF
 bHJ
 pbm
@@ -76869,7 +77143,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+bNw
 bGE
 bGE
 bIV
@@ -77125,10 +77399,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+mVM
+nwz
 bGG
-bHL
+bGG
 aHE
 bKc
 eVb
@@ -77383,9 +77657,9 @@ hXW
 hXW
 hXW
 hXW
-aaa
-bGH
-bGE
+bNw
+bGG
+bHN
 cqI
 bKd
 bLp
@@ -77638,11 +77912,11 @@ aht
 bns
 bbU
 tow
-aHy
-hXW
-aaa
-bGI
-bHM
+baK
+baK
+pMv
+bGG
+bHN
 bHM
 bHM
 bLq
@@ -77895,10 +78169,10 @@ aht
 aZx
 bbU
 baK
-aHy
-hXW
-aaa
-aaa
+bdZ
+bdZ
+hvt
+bGG
 bHN
 bGE
 bKe
@@ -78152,11 +78426,11 @@ aZx
 aZx
 bbU
 baK
-aHy
+eMM
 hXW
-aaa
-aaa
-bGI
+bNw
+bNw
+bNw
 bGE
 bKf
 aHM
@@ -78409,7 +78683,7 @@ cKI
 ryi
 bbU
 baK
-aHy
+eMM
 hXW
 aaa
 aaa
@@ -78666,8 +78940,8 @@ aZx
 aZx
 bbU
 baK
-nAS
-hXW
+eMM
+aZx
 aaa
 aaa
 bGI
@@ -78922,9 +79196,9 @@ aZx
 pCe
 bbU
 vrJ
-baK
+bea
 sGO
-hXW
+aZx
 aaa
 aaa
 aaa
@@ -79179,9 +79453,9 @@ aZx
 xDY
 bbU
 baK
-baK
+iVx
 eMM
-hXW
+aZx
 aaa
 aaa
 aaa
@@ -79435,10 +79709,10 @@ aaa
 aZx
 fUx
 bbU
-bdY
+baK
 bdW
 ybs
-hXW
+aZx
 aaa
 aaa
 aaa
@@ -79695,7 +79969,7 @@ bbU
 baK
 irU
 eMM
-hXW
+aZx
 aaa
 aaa
 aaa
@@ -79952,7 +80226,7 @@ bbU
 bbU
 irU
 eMM
-hXW
+aZx
 aaa
 aaa
 aaa
@@ -80211,7 +80485,7 @@ irU
 eMM
 aZx
 aaa
-maV
+aaa
 aaa
 jCF
 aaa
@@ -85782,7 +86056,7 @@ aew
 iBg
 pah
 dfW
-nwz
+ahL
 bnC
 aiO
 qUZ
@@ -86802,7 +87076,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gYo
 aby
 aaa
 aew
@@ -86815,7 +87089,7 @@ cnJ
 nrx
 qwn
 ajm
-ixW
+gyU
 anM
 alD
 amo
@@ -87059,7 +87333,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
 aht
 aew
@@ -87070,9 +87343,10 @@ aew
 aew
 aew
 aew
+aew
 qwn
 ajn
-ixW
+gyU
 qTO
 feH
 amp
@@ -87316,7 +87590,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
 aaa
 aic
@@ -87326,8 +87599,9 @@ cnN
 cnV
 gyR
 tuJ
-anM
-agP
+rmN
+mlD
+vBh
 ajo
 tbD
 dhu
@@ -87573,20 +87847,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
 bBW
 aic
-ark
+nAS
 rdI
 pXC
-pXC
-gyR
+pFV
+aiQ
+kpN
 jiQ
 sbr
-agP
+pKg
 ajp
-rcV
+tbD
 anM
 alF
 amq
@@ -87668,7 +87942,7 @@ bNO
 uOA
 mMd
 uqs
-uqs
+ark
 fkX
 sOB
 aht
@@ -87830,16 +88104,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
 aaa
 aic
 aFa
 wtO
 wtO
-mDL
-aiQ
-gyU
+owq
+gyR
+uXC
+ico
 hBD
 waf
 cUr
@@ -88087,7 +88361,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
 aaa
 aic
@@ -88095,10 +88368,11 @@ upT
 wlO
 cnV
 cnV
-qgK
+bHL
+bHL
 eIr
 oYQ
-qgK
+bHL
 glZ
 agP
 cCS
@@ -88344,7 +88618,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 acO
 aaa
 aic
@@ -88352,11 +88625,12 @@ jda
 wlO
 cnV
 cnV
-qgK
-pxb
+bHL
+rbm
+peh
 lBt
-lBt
-uNz
+rtb
+oYy
 aiR
 akT
 aiR
@@ -88601,7 +88875,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
 aaa
 aic
@@ -88609,6 +88882,7 @@ jda
 wlO
 cnV
 cnV
+bHL
 qgK
 fVq
 tIf
@@ -88858,18 +89132,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
 aaa
 aig
 jda
 fpQ
-kpN
+fkV
 cnV
-qgK
+bHL
+gVI
 pxb
-lBt
-qbK
+xkU
+prm
 aiR
 aka
 qeT
@@ -89115,7 +89389,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
 aht
 aic
@@ -89123,11 +89396,12 @@ aXi
 rNN
 rNN
 rNN
-qgK
+bHL
+xYY
 uMv
 uNz
 qbK
-aiR
+rcV
 akb
 akW
 alK
@@ -89372,7 +89646,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aby
 aaa
 aic
@@ -89380,7 +89653,8 @@ aig
 aic
 aic
 tTx
-qgK
+bHL
+hpP
 hpP
 hpP
 hpP
@@ -89629,7 +89903,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+gYo
 aby
 aaa
 aaa
@@ -91715,7 +91989,7 @@ auP
 asS
 asS
 ayg
-oQp
+jPb
 asS
 aBr
 aDJ
@@ -91772,7 +92046,7 @@ bsK
 xqq
 bsK
 bsK
-bsK
+rvi
 ftz
 bpY
 bTl
@@ -92799,7 +93073,7 @@ rCo
 tcX
 uIo
 rlT
-bsK
+rya
 bsK
 foK
 bpY
@@ -94564,7 +94838,7 @@ aKY
 kVO
 aPE
 aVh
-bah
+mGR
 bah
 daB
 cpi
@@ -94821,7 +95095,7 @@ aKY
 kVO
 aPE
 aVi
-bah
+mGR
 aXh
 cyM
 aZd
@@ -95078,7 +95352,7 @@ aRX
 aST
 aPE
 cpb
-bah
+mGR
 bah
 pVr
 cpi
@@ -97439,7 +97713,7 @@ bSd
 mUY
 vSL
 gNi
-fby
+oYJ
 fby
 igl
 jhA
@@ -98687,7 +98961,7 @@ cct
 cct
 vRC
 aDZ
-aDZ
+mMA
 bhP
 bih
 bjm
@@ -103311,7 +103585,7 @@ bbK
 bcF
 bfH
 beO
-bfH
+ixW
 bgM
 bhu
 bbI
@@ -103559,7 +103833,7 @@ aTq
 aTq
 ebw
 aUw
-aWB
+uLC
 aXy
 cCT
 cCT
@@ -104068,7 +104342,7 @@ aMw
 aQo
 aXC
 bcT
-cCB
+edu
 cCB
 aTs
 aUz
@@ -104842,7 +105116,7 @@ aTv
 bfC
 oMH
 bcV
-aSk
+iZK
 cdj
 evg
 doQ

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -4745,10 +4745,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ark" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/hos)
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/chapel/dock)
 "arl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15789,12 +15791,6 @@
 /obj/machinery/griddle,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
-"bdw" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/landmark/secequipment,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "bdy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -16500,12 +16496,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel/monastery)
-"bgd" = (
-/obj/structure/training_machine,
-/obj/effect/turf_decal/trimline/yellow,
-/obj/item/target/clown,
-/turf/open/floor/iron/dark,
-/area/station/security/range)
 "bge" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4;
@@ -23196,12 +23186,9 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/dock)
 "bGG" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/service/chapel/dock)
 "bGH" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/space,
@@ -23360,8 +23347,12 @@
 /area/station/service/chapel/dock)
 "bHL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/chapel/dock)
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "bHM" = (
 /turf/closed/wall/r_wall,
 /area/station/service/chapel/dock)
@@ -24357,12 +24348,6 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"bML" = (
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/range)
 "bMM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33844,13 +33829,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"cTg" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/recharge_floor,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "cTI" = (
 /obj/structure/table,
 /obj/item/food/ready_donk/mac_n_cheese{
@@ -33879,21 +33857,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"cUH" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/ammo_workbench,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/range)
 "cVo" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -34867,15 +34830,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"dKy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "dKA" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 1
@@ -34979,9 +34933,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
-"dQs" = (
-/turf/open/floor/plating,
-/area/space/nearstation)
 "dQB" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/binary/tank_compressor{
@@ -36324,6 +36275,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"fak" = (
+/obj/structure/training_machine,
+/obj/effect/turf_decal/trimline/yellow,
+/obj/item/target/clown,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "fal" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -37614,6 +37571,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/main)
+"fQP" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/hos)
 "fQT" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -37824,10 +37786,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
-"gat" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/station/service/bar)
 "gaF" = (
 /obj/machinery/button/door{
 	id = "prisonereducation";
@@ -38330,6 +38288,11 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"grN" = (
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "grR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -38346,14 +38309,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/research)
-"gth" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/item/toy/plush/skyrat/derg_plushie,
-/obj/structure/table/wood,
-/turf/open/floor/iron/white,
-/area/station/medical/psychology)
 "gtl" = (
 /obj/item/toy/crayon/black,
 /obj/item/toy/crayon/white{
@@ -38848,6 +38803,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"gMu" = (
+/turf/open/floor/plating,
+/area/space/nearstation)
 "gMG" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -39636,16 +39594,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms/barracks)
-"hou" = (
-/obj/structure/cable,
-/obj/machinery/mech_bay_recharge_port{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/circuit/red,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "hox" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
@@ -39703,6 +39651,15 @@
 /obj/item/reagent_containers/cup/glass/bottle/vodka,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
+"hsR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "hsS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -39828,10 +39785,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
-"hxj" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "hxH" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
@@ -40352,6 +40305,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/burnchamber)
+"hPs" = (
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "hPI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -41166,6 +41124,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"ixx" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "ixN" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 5
@@ -41192,9 +41154,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ixW" = (
-/obj/item/toy/plush/skyrat/plushie_dan,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/station/service/chapel/dock)
 "ixY" = (
 /obj/structure/sink/directional/west,
 /obj/structure/cable,
@@ -41414,16 +41376,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"iHd" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/mapping_helpers/apc/cell_5k,
-/obj/structure/cable,
-/obj/machinery/mechpad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "iHM" = (
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
@@ -41900,20 +41852,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"jaR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "jbh" = (
 /obj/structure/railing{
 	dir = 8
@@ -41927,12 +41865,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
-"jbR" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/west,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/landmark/secequipment,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "jbV" = (
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -42268,6 +42200,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"jph" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "jpt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/turf_decal/bot_blue,
@@ -42464,6 +42400,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"jxH" = (
+/obj/item/virgin_mary,
+/turf/closed/wall,
+/area/station/service/chapel/monastery)
 "jxM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -43453,13 +43393,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "kpN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/range)
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "kpW" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable,
@@ -43754,6 +43690,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
+"kBe" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "kBm" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -44027,6 +43969,12 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
+"kJG" = (
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/landmark/secequipment,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "kKl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -44517,12 +44465,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"lcx" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "lcA" = (
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/engine,
@@ -45126,10 +45068,13 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms/barracks)
 "lBt" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/lesser{
 	name = "Security Mech Maintenance Bay"
@@ -46585,12 +46530,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "mDL" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/station/service/chapel/dock)
+/area/station/cargo/storage)
 "mDW" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -47053,6 +46998,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
+"mXZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "mYa" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -47660,11 +47613,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "nAS" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
-	},
-/turf/open/floor/iron,
-/area/station/service/chapel/dock)
+/obj/item/toy/plush/skyrat/plushie_dan,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "nBt" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -48005,6 +47956,15 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"nLS" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "nLU" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/machinery/light/directional/south,
@@ -48053,15 +48013,6 @@
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /turf/open/floor/wood/parquet,
 /area/station/service/jadedragon)
-"nNc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 5
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "nNk" = (
 /obj/machinery/status_display/supply{
 	dir = 4;
@@ -48680,12 +48631,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
-"okP" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "olc" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bedroom"
@@ -49847,6 +49792,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"oZN" = (
+/obj/structure/cable,
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/red,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "oZP" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -50247,12 +50202,9 @@
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "prm" = (
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "prr" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -50497,6 +50449,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"pAO" = (
+/obj/structure/table,
+/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
+	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob";
+	pixel_y = 9;
+	pixel_x = -10
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 12
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "pAR" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -51294,10 +51268,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "qbK" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/lesser{
 	name = "Security Mech Maintenance Bay"
@@ -51409,7 +51381,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qgK" = (
-/turf/closed/wall/r_wall,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/obj/machinery/mechpad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/lesser{
 	name = "Security Mech Maintenance Bay"
 	})
@@ -52659,9 +52636,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "rcV" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "rdn" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/engineering_welding,
@@ -52820,11 +52799,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
-"rin" = (
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "riH" = (
 /obj/structure/table,
 /turf/open/floor/iron/kitchen,
@@ -53271,28 +53245,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"rxB" = (
-/obj/structure/table,
-/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
-	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob";
-	pixel_y = 9;
-	pixel_x = -10
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "rxI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53560,6 +53512,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms/barracks)
+"rGp" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "rGq" = (
 /obj/item/kirbyplants/organic/plant18,
 /obj/effect/turf_decal/tile/neutral{
@@ -53939,14 +53897,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"rWn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "rWE" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -54481,10 +54431,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"suo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/station/service/chapel/dock)
 "sut" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/space/basic,
@@ -55023,6 +54969,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"sSz" = (
+/turf/open/space/basic,
+/area/station/command/bridge)
 "sSE" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
@@ -55787,6 +55736,14 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"tsk" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/item/toy/plush/skyrat/derg_plushie,
+/obj/structure/table/wood,
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "ttB" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -56077,6 +56034,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/station/engineering/atmospherics_engine)
+"tFe" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel"
+	},
+/turf/open/floor/iron,
+/area/station/service/chapel/dock)
 "tFt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/painting/library_private{
@@ -57079,11 +57042,6 @@
 "uoS" = (
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
-"upd" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "upO" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -57927,6 +57885,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
+"uXi" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/landmark/secequipment,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "uXE" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
@@ -58537,6 +58501,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
+"vrq" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "vrr" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 4;
@@ -58677,6 +58646,15 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"vvm" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "vvD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58684,14 +58662,6 @@
 /obj/effect/turf_decal/trimline/purple/warning,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"vvF" = (
-/obj/structure/cable,
-/obj/machinery/computer/mech_bay_power_console,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/circuit/red,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "vvV" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "pod_arrive"
@@ -59170,6 +59140,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"vPZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 5
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "vQo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Office Maintenance"
@@ -59276,10 +59255,6 @@
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
-"vSA" = (
-/obj/item/virgin_mary,
-/turf/closed/wall,
-/area/station/service/chapel/monastery)
 "vSG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -59822,6 +59797,21 @@
 /obj/item/pestle,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"wpr" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/ammo_workbench,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "wpE" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/dark,
@@ -60922,6 +60912,20 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"xdp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "xdx" = (
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
@@ -61400,21 +61404,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"xuk" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
-"xum" = (
-/turf/open/space/basic,
-/area/station/command/bridge)
 "xur" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -61555,10 +61544,6 @@
 /obj/item/assembly/timer,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"xyn" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "xyB" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -61640,6 +61625,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"xBO" = (
+/obj/structure/cable,
+/obj/machinery/computer/mech_bay_power_console,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/red,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "xCm" = (
 /obj/structure/closet/wardrobe/green,
 /turf/open/floor/iron/dark,
@@ -62467,6 +62460,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"yhJ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron/recharge_floor,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "yhV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -75120,7 +75120,7 @@ kcx
 cfN
 cfN
 cfN
-vSA
+jxH
 bXJ
 cve
 cuK
@@ -76886,7 +76886,7 @@ aaa
 aaa
 aaa
 aaa
-dQs
+gMu
 bGF
 bHJ
 pbm
@@ -77400,9 +77400,9 @@ aaa
 aaa
 aaa
 mVM
-suo
-bHL
-bHL
+ixW
+bGG
+bGG
 aHE
 bKc
 eVb
@@ -77658,7 +77658,7 @@ hXW
 hXW
 hXW
 bNw
-bHL
+bGG
 bHN
 cqI
 bKd
@@ -77914,8 +77914,8 @@ bbU
 tow
 baK
 baK
-nAS
-bHL
+tFe
+bGG
 bHN
 bHM
 bHM
@@ -78171,8 +78171,8 @@ bbU
 baK
 bdZ
 bdZ
-mDL
-bHL
+ark
+bGG
 bHN
 bGE
 bKe
@@ -87599,9 +87599,9 @@ cnN
 cnV
 gyR
 tuJ
-jbR
-bdw
-rin
+uXi
+kJG
+grN
 ajo
 tbD
 dhu
@@ -87850,15 +87850,15 @@ aaa
 aby
 bBW
 aic
-cUH
+wpr
 rdI
 pXC
-bML
+rcV
 aiQ
-rWn
+bHL
 jiQ
 sbr
-okP
+kBe
 ajp
 tbD
 anM
@@ -87942,7 +87942,7 @@ bNO
 uOA
 mMd
 uqs
-gth
+tsk
 fkX
 sOB
 aht
@@ -88110,10 +88110,10 @@ aic
 aFa
 wtO
 wtO
-kpN
+mXZ
 gyR
-nNc
-dKy
+vPZ
+hsR
 hBD
 waf
 cUr
@@ -88368,11 +88368,11 @@ upT
 wlO
 cnV
 cnV
-qgK
-qgK
+hPs
+hPs
 eIr
 oYQ
-qgK
+hPs
 glZ
 agP
 cCS
@@ -88625,11 +88625,11 @@ jda
 wlO
 cnV
 cnV
-qgK
-vvF
-jaR
+hPs
+xBO
+xdp
+nLS
 lBt
-xuk
 uNz
 aiR
 akT
@@ -88882,11 +88882,11 @@ jda
 wlO
 cnV
 cnV
-qgK
-cTg
+hPs
+yhJ
 fVq
 tIf
-prm
+qbK
 aiR
 aiR
 akU
@@ -89137,13 +89137,13 @@ aaa
 aig
 jda
 fpQ
-bgd
+fak
 cnV
-qgK
-hou
+hPs
+oZN
 pxb
-lcx
-prm
+rGp
+qbK
 aiR
 aka
 qeT
@@ -89396,12 +89396,12 @@ aXi
 rNN
 rNN
 rNN
+hPs
 qgK
-iHd
 uMv
-rxB
-qbK
-ark
+pAO
+vvm
+fQP
 akb
 akW
 alK
@@ -89653,7 +89653,7 @@ aig
 aic
 aic
 tTx
-qgK
+hPs
 hpP
 hpP
 hpP
@@ -91989,7 +91989,7 @@ auP
 asS
 asS
 ayg
-xum
+sSz
 asS
 aBr
 aDJ
@@ -92046,7 +92046,7 @@ bsK
 xqq
 bsK
 bsK
-ixW
+nAS
 ftz
 bpY
 bTl
@@ -93073,7 +93073,7 @@ rCo
 tcX
 uIo
 rlT
-hxj
+kpN
 bsK
 foK
 bpY
@@ -94838,7 +94838,7 @@ aKY
 kVO
 aPE
 aVh
-gat
+ixx
 bah
 daB
 cpi
@@ -95095,7 +95095,7 @@ aKY
 kVO
 aPE
 aVi
-gat
+ixx
 aXh
 cyM
 aZd
@@ -95352,7 +95352,7 @@ aRX
 aST
 aPE
 cpb
-gat
+ixx
 bah
 pVr
 cpi
@@ -103585,7 +103585,7 @@ bbK
 bcF
 bfH
 beO
-rcV
+prm
 bgM
 bhu
 bbI
@@ -103833,7 +103833,7 @@ aTq
 aTq
 ebw
 aUw
-bGG
+mDL
 aXy
 cCT
 cCT
@@ -104342,7 +104342,7 @@ aMw
 aQo
 aXC
 bcT
-xyn
+jph
 cCB
 aTs
 aUz
@@ -104609,13 +104609,13 @@ baB
 cCB
 rCu
 pvZ
-oex
-oex
-oex
+aht
+aht
+aht
 bdI
 oPy
 bdI
-oex
+aht
 aEj
 aEj
 bHC
@@ -105116,7 +105116,7 @@ aTv
 bfC
 oMH
 bcV
-upd
+vrq
 cdj
 evg
 doQ

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2165,13 +2165,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "aij" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "aik" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron/dark,
@@ -3127,8 +3123,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "alx" = (
-/turf/closed/wall/r_wall,
-/area/station/hallway/secondary/construction)
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "aly" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -4048,6 +4048,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"aou" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/chair/office{
+	color = "#52B4E9";
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/bitrunning/den)
 "aov" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -14907,6 +14923,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"bay" = (
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "baz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14938,17 +14961,23 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "baC" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "baD" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "jangarage";
+	name = "Custodial Closet Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/security/tram)
 "baE" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/bot,
@@ -16527,21 +16556,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"bgj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/board_number/one{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/brown/line,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/engine,
-/area/station/bitrunning/den)
 "bgk" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -19682,6 +19696,13 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
 /area/station/science/xenobiology)
+"brS" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "brT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -19986,6 +20007,23 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
+"bsS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 7
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "bsT" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -20920,6 +20958,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"bxa" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "bxd" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -22341,15 +22386,20 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bCv" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/item/toy/plush/moth{
-	name = "Wereni Moff"
+/obj/effect/turf_decal/board_number/one{
+	dir = 1
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/engine,
+/area/station/bitrunning/den)
 "bCx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
@@ -24878,12 +24928,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"bPk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "bPn" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
@@ -33620,12 +33664,6 @@
 "cLN" = (
 /turf/open/floor/plating,
 /area/station/security/prison)
-"cLU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "cMl" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -33672,9 +33710,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"cNR" = (
-/turf/closed/wall,
-/area/station/hallway/secondary/construction)
 "cOA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral,
@@ -33792,6 +33827,23 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"cTI" = (
+/obj/structure/table,
+/obj/item/food/ready_donk/mac_n_cheese{
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/obj/item/food/ready_donk/nachos_grandes{
+	pixel_y = 7
+	},
+/obj/item/food/ready_donk/donkhiladas{
+	pixel_y = 11;
+	pixel_x = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "cUr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -33811,6 +33863,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
+"cVE" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "cVH" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room"
@@ -33883,9 +33941,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"cYK" = (
-/turf/open/floor/wood/cold,
-/area/station/hallway/secondary/construction)
+"cZt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "daB" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red{
@@ -34091,6 +34154,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"dkk" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/computer/order_console/bitrunning,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "dkn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -34288,13 +34359,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
-"drv" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/rack,
-/obj/structure/cable,
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "drS" = (
 /obj/machinery/camera/preset/ordnance{
 	c_tag = "Bomb Testing Site2";
@@ -34381,13 +34445,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"dvc" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "dvH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/brown{
@@ -34740,15 +34797,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"dIf" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "dIn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/mapping_helpers/broken_floor,
@@ -35045,6 +35093,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"dXc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "dXg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -35089,15 +35143,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"eaU" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	id = "jangarage";
-	name = "Custodial Closet Shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/security/tram)
 "ebi" = (
 /obj/item/bedsheet/ian,
 /obj/structure/bed,
@@ -35463,6 +35508,11 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"eqr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/plating,
+/area/station/engineering/lobby)
 "eqD" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -35699,18 +35749,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"eDM" = (
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/security/armory)
-"eEa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
-/obj/effect/landmark/start/bitrunner,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "eEp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -35857,6 +35895,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/crew_quarters/dorms)
+"eIr" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters{
+	id = "jangarage";
+	name = "Custodial Closet Shutters"
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/construction)
 "eIL" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -35946,23 +35992,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"eNz" = (
-/obj/structure/table,
-/obj/item/food/cornchips/blue{
-	pixel_x = 9;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/soda_cans/space_mountain_wind{
-	pixel_x = -7;
-	pixel_y = -1
-	},
-/obj/item/food/cornchips/red{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "eNF" = (
 /turf/closed/wall,
 /area/space/nearstation)
@@ -35993,6 +36022,12 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"eOW" = (
+/obj/machinery/computer/quantum_console{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/bitrunning/den)
 "eOZ" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/costume/judgerobe,
@@ -36019,6 +36054,12 @@
 /obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton,
 /turf/open/floor/wood,
 /area/station/maintenance/department/crew_quarters/dorms)
+"eQn" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "eQL" = (
 /obj/structure/table,
 /obj/item/storage/fancy/egg_box,
@@ -36247,17 +36288,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
-"faU" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 8
-	},
-/obj/item/kirbyplants/organic/plant7,
-/turf/open/floor/engine,
-/area/station/bitrunning/den)
 "faY" = (
 /turf/closed/wall,
 /area/centcom/asteroid/nearstation/bomb_site)
@@ -36416,13 +36446,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"fen" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "fer" = (
 /obj/machinery/power/shieldwallgen,
 /obj/structure/disposalpipe/segment{
@@ -36753,6 +36776,14 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/service/jadedragon)
+"frl" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "frC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -36981,13 +37012,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms/barracks)
-"fym" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "fyO" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
@@ -37132,15 +37156,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"fEC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "fER" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -37189,6 +37204,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"fFG" = (
+/obj/structure/sign/poster/contraband/random/directional/west,
+/obj/machinery/netpod,
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/bitrunning/den)
 "fFN" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -37554,6 +37575,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"fRc" = (
+/obj/machinery/button/delam_scram,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "fSg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37600,6 +37625,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
+"fVq" = (
+/obj/structure/cable,
+/obj/machinery/computer,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
 "fVT" = (
 /obj/machinery/computer/security/telescreen/ordnance{
 	dir = 1;
@@ -37837,14 +37867,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"gen" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_lockdown";
-	name = "Chemistry Shutters"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "gfi" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 2
@@ -37924,6 +37946,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"ggK" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "ggX" = (
 /obj/structure/table/wood/shuttle_bar,
 /obj/item/lipstick/random,
@@ -38095,12 +38125,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"glZ" = (
+/turf/closed/wall,
+/area/station/hallway/secondary/construction)
 "gma" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "gmA" = (
@@ -38216,6 +38245,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"gru" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "grR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -38425,6 +38461,12 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
+"gzw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "gAG" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -39029,14 +39071,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
-"gXu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "gXT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -39771,12 +39805,9 @@
 /area/station/commons/fitness/recreation)
 "hzE" = (
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "hzF" = (
@@ -39917,11 +39948,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "hDh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/turf/open/floor/iron/stairs{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/bitrunning/den)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxiliary Base Construction"
@@ -40044,15 +40075,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/plating,
 /area/station/commons/toilet/restrooms)
-"hJf" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "hJO" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Prison Forestry"
@@ -40643,6 +40665,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/theater)
+"icY" = (
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/board_number/three{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/station/bitrunning/den)
 "idj" = (
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -40718,13 +40755,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "igy" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/railing{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/computer/order_console/bitrunning,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "igC" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -40819,12 +40857,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"ile" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "ilD" = (
 /obj/machinery/processor/slime,
 /turf/open/floor/iron/white,
@@ -41169,13 +41201,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"iCE" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "iDw" = (
 /obj/effect/turf_decal/vg_decals/atmos/mix{
 	dir = 1
@@ -41397,12 +41422,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
-"iJL" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "iKb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
@@ -41748,6 +41767,22 @@
 "iYT" = (
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"iZq" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
+"jaC" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "jaI" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -41943,6 +41978,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"jiQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "jjm" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/organic/plant24{
@@ -42062,9 +42103,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"joe" = (
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
 "jor" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -42154,13 +42192,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"jrX" = (
-/obj/machinery/light/floor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "jsf" = (
 /obj/item/toy/katana,
 /turf/open/floor/plating,
@@ -42307,11 +42338,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
-"jyc" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/quantum_server,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/bitrunning/den)
 "jyg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42541,6 +42567,12 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"jGp" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "jGt" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
@@ -43239,11 +43271,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/auxlab)
+"kmN" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/rack,
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "knD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/executive,
 /area/station/commons/dorms/barracks)
+"knG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/byteforge,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/bitrunning/den)
 "knP" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
@@ -43576,12 +43619,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
-"kBl" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "kBm" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -44044,12 +44081,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
-"kRv" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/west,
-/turf/open/floor/iron/stairs{
-	dir = 1
-	},
-/area/station/bitrunning/den)
 "kRH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -44074,11 +44105,6 @@
 /obj/structure/closet/crate/critter,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"kSu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/byteforge,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/bitrunning/den)
 "kSA" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -44350,12 +44376,6 @@
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
-"lcB" = (
-/obj/structure/sign/poster/contraband/random/directional/west,
-/obj/machinery/netpod,
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/bitrunning/den)
 "lcG" = (
 /obj/item/clothing/suit/caution{
 	pixel_y = 8
@@ -44658,10 +44678,6 @@
 /obj/item/statuebust,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
-"lpK" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "lqc" = (
 /obj/item/toy/gun,
 /obj/effect/decal/cleanable/oil,
@@ -44832,6 +44848,15 @@
 /obj/item/cigbutt/cigarbutt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"lur" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lvr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -44949,6 +44974,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms/barracks)
+"lBt" = (
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
 "lBG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/glass/reinforced,
@@ -45187,6 +45215,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
+"lIs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "lIu" = (
 /obj/machinery/shower/directional/east{
 	name = "emergency shower"
@@ -45359,6 +45393,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine)
+"lRn" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "lRS" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
@@ -45432,16 +45473,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
-"lVC" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "lVG" = (
 /obj/effect/turf_decal/vg_decals/radiation_huge,
 /obj/structure/cable/layer1,
@@ -45532,6 +45563,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"lZY" = (
+/obj/structure/sign/delam_procedure,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "mau" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
@@ -45930,20 +45965,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "mqp" = (
-/obj/effect/landmark/start/bitrunner,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/board_number/two{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/trimline/brown/line,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
+/turf/closed/wall,
 /area/station/bitrunning/den)
 "mqD" = (
 /obj/machinery/cryopod{
@@ -46523,11 +46548,6 @@
 "mKE" = (
 /turf/closed/wall,
 /area/station/medical/medbay/lobby)
-"mKJ" = (
-/obj/structure/cable,
-/obj/machinery/computer,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
 "mLv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -46991,15 +47011,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
-"ncr" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "ndc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -47212,17 +47223,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
-"nju" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/item/modular_computer/laptop/preset/civilian{
-	pixel_y = 5;
-	pixel_x = 2
-	},
-/obj/structure/table,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "nkd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -47276,10 +47276,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"nmX" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "nnb" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/light_switch{
@@ -47442,6 +47438,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
+"nwz" = (
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/security/armory)
 "nwH" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Atmospherics Tank - Toxins";
@@ -47449,15 +47449,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
-"nxF" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "nxG" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/disposalpipe/segment{
@@ -47795,6 +47786,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/commons/dorms/barracks)
+"nJy" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_lockdown";
+	name = "Chemistry Shutters"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "nJH" = (
 /obj/structure/closet/wardrobe/white,
 /obj/effect/turf_decal/tile/neutral{
@@ -47939,6 +47938,12 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/station/medical/storage)
+"nOQ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "nOV" = (
 /turf/closed/wall,
 /area/station/bitrunning/den)
@@ -48046,6 +48051,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
+"nSG" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/obj/item/kirbyplants/organic/plant7,
+/turf/open/floor/engine,
+/area/station/bitrunning/den)
 "nTn" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -48080,11 +48096,6 @@
 /obj/structure/flora/bush/jungle/b/style_random,
 /turf/open/floor/grass,
 /area/station/medical/treatment_center)
-"nUc" = (
-/obj/structure/cable,
-/obj/structure/table_frame,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
 "nUg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -48284,10 +48295,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"oei" = (
-/obj/machinery/button/delam_scram,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
 "oex" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -48317,16 +48324,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
-"ofn" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "oft" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment{
@@ -49042,13 +49039,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
-"oCS" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "oDk" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -49101,12 +49091,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"oEn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "oEz" = (
 /obj/item/inspector{
 	pixel_x = -5;
@@ -49324,13 +49308,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet/restrooms)
-"oMB" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "oMH" = (
 /obj/structure/table,
 /obj/item/airlock_painter/decal,
@@ -50093,6 +50070,9 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
+"prm" = (
+/turf/open/floor/wood/cold,
+/area/station/hallway/secondary/construction)
 "prr" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -50209,11 +50189,7 @@
 /area/space/nearstation)
 "pxb" = (
 /obj/structure/cable,
-/obj/machinery/door/poddoor/shutters{
-	id = "jangarage";
-	name = "Custodial Closet Shutters"
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "pxO" = (
 /obj/item/transfer_valve{
@@ -50340,6 +50316,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"pAT" = (
+/obj/structure/sign/warning/vacuum/external/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "pAX" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral{
@@ -50638,12 +50618,6 @@
 /obj/effect/turf_decal/trimline/dark_blue/line,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
-"pKC" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "pKT" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
@@ -50760,6 +50734,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"pOn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "pOr" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -50831,6 +50811,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
+"pPZ" = (
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/board_number/two{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/station/bitrunning/den)
 "pQb" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Atmospherics Tank - Air";
@@ -50842,10 +50838,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/service/library/artgallery)
-"pQJ" = (
-/obj/structure/sign/warning/vacuum/external/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "pQQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
@@ -50895,10 +50887,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
-"pTn" = (
-/obj/structure/table_frame,
-/turf/open/floor/wood/cold,
-/area/station/hallway/secondary/construction)
 "pTy" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
@@ -50992,6 +50980,16 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
+"pXJ" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "pXT" = (
 /obj/item/kirbyplants,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -51107,6 +51105,10 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"qbK" = (
+/obj/structure/table_frame,
+/turf/open/floor/wood/cold,
+/area/station/hallway/secondary/construction)
 "qbZ" = (
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -51178,6 +51180,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
+"qfC" = (
+/obj/machinery/light/floor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "qgw" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -51206,11 +51215,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qgK" = (
-/obj/machinery/computer/quantum_console{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/bitrunning/den)
+/turf/closed/wall/r_wall,
+/area/station/hallway/secondary/construction)
 "qgM" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
@@ -51437,12 +51443,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"qoM" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/rack,
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "qoS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -51971,6 +51971,16 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"qId" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start/bitrunner,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "qIl" = (
 /obj/machinery/computer/pandemic,
 /obj/machinery/airalarm/directional/north,
@@ -52181,13 +52191,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"qQI" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "qQQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -52293,6 +52296,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"qUZ" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/rack,
+/obj/structure/cable,
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "qVb" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/blueshield)
@@ -52380,15 +52390,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"qYY" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "qZc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -52470,12 +52471,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"rdm" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "rdn" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/engineering_welding,
@@ -52497,6 +52492,12 @@
 "rdQ" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/storage/gas)
+"rek" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "reH" = (
 /obj/item/reagent_containers/cup/glass/bottle/vodka,
 /obj/structure/disposalpipe/segment{
@@ -52544,11 +52545,6 @@
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
-"rfX" = (
-/obj/machinery/netpod,
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/bitrunning/den)
 "rfZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -52874,6 +52870,11 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
+"rrB" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "rrU" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -53386,11 +53387,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"rHV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
 "rIw" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -53648,6 +53644,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
+"rSF" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "rSH" = (
 /obj/item/trash/can,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -53913,6 +53913,15 @@
 /obj/item/key/security,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"sdp" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "sdZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrogen_output{
 	dir = 1
@@ -53940,11 +53949,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "seY" = (
-/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
-	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob"
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/construction)
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "sfo" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -54403,6 +54415,11 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"sAR" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/quantum_server,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/bitrunning/den)
 "sBf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -54918,6 +54935,26 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"sXQ" = (
+/obj/structure/table,
+/obj/item/food/cornchips/blue{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/cup/soda_cans/space_mountain_wind{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/food/cornchips/red{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "sXR" = (
 /obj/structure/disposalpipe/junction,
 /turf/closed/wall/r_wall,
@@ -55743,10 +55780,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"tCq" = (
-/obj/structure/sign/delam_procedure,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
 "tCC" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -55885,6 +55918,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
+"tIf" = (
+/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
+	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
 "tIl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55952,13 +55991,6 @@
 "tLe" = (
 /turf/closed/wall,
 /area/station/security/execution/education)
-"tLH" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/machinery/light/small/directional/east,
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "tLK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -55972,22 +56004,6 @@
 	},
 /turf/closed/wall,
 /area/station/cargo/sorting)
-"tMb" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/line,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/chair/office{
-	color = "#52B4E9";
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/bitrunning/den)
 "tMk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56072,6 +56088,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
+"tOe" = (
+/obj/machinery/netpod,
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/bitrunning/den)
 "tOf" = (
 /obj/structure/sign/poster/random/directional/north,
 /obj/machinery/conveyor_switch/oneway{
@@ -56457,6 +56478,14 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"ucW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/effect/landmark/start/bitrunner,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "udk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -56810,6 +56839,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance_storage,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"uoD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "uoS" = (
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
@@ -57073,6 +57108,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"uyk" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/item/modular_computer/laptop/preset/civilian{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/obj/structure/table,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "uyy" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -57183,12 +57229,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"uBG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/station/bitrunning/den)
 "uCe" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
@@ -57292,23 +57332,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
-"uIa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 7
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/corner{
-	dir = 1
-	},
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "uIo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57427,6 +57450,7 @@
 /area/station/maintenance/department/engine)
 "uMv" = (
 /obj/structure/cable,
+/obj/structure/table_frame,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
 "uMY" = (
@@ -57566,21 +57590,6 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
-"uSY" = (
-/obj/effect/landmark/start/bitrunner,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/board_number/three{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/line,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/station/bitrunning/den)
 "uTi" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/cell_5k,
@@ -57644,6 +57653,16 @@
 /obj/item/stamp/law,
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
+"uVo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "uVt" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
@@ -57662,13 +57681,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"uWy" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "uXE" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
@@ -58485,17 +58497,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "vxg" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Comissary Back Room"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
+/obj/machinery/incident_display/delam/directional/west,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "vxp" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
@@ -58789,10 +58793,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"vNk" = (
-/obj/machinery/incident_display/delam/directional/west,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
 "vNr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
@@ -58832,13 +58832,6 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/command/heads_quarters/blueshield)
-"vOi" = (
-/obj/effect/landmark/start/bitrunner,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "vOw" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -58873,6 +58866,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"vPh" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Comissary Back Room"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "vPE" = (
 /obj/structure/chair/office/light,
 /obj/effect/turf_decal/tile/blue{
@@ -59506,10 +59511,16 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space)
-"wmr" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+"wmJ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/toy/plush/moth{
+	name = "Wereni Moff"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "wns" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plating,
@@ -59597,6 +59608,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"wrE" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "wrU" = (
 /obj/machinery/photocopier,
 /obj/machinery/firealarm/directional/west,
@@ -60930,15 +60945,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
-"xmq" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "xmE" = (
 /obj/structure/chair{
 	dir = 8
@@ -61169,12 +61175,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/jadedragon)
-"xva" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "xvO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61225,6 +61225,13 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"xxA" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/machinery/light/small/directional/east,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "xxC" = (
 /obj/machinery/door/poddoor{
 	id = "SecJusticeChamber";
@@ -61408,6 +61415,16 @@
 /obj/machinery/computer/shuttle/arrivals/recall,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"xEl" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "xEt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -61600,12 +61617,6 @@
 "xLv" = (
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
-"xLx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "xLC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -61738,16 +61749,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
-"xPM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/landmark/start/bitrunner,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "xQn" = (
 /obj/effect/turf_decal/stripes{
 	dir = 5
@@ -61782,6 +61783,15 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
+"xQM" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "xQO" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -61846,23 +61856,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
-"xUQ" = (
-/obj/structure/table,
-/obj/item/food/ready_donk/mac_n_cheese{
-	pixel_y = 3;
-	pixel_x = 2
-	},
-/obj/item/food/ready_donk/nachos_grandes{
-	pixel_y = 7
-	},
-/obj/item/food/ready_donk/donkhiladas{
-	pixel_y = 11;
-	pixel_x = 1
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "xUU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62103,10 +62096,20 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"ydr" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "ydL" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "ydZ" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -84754,7 +84757,7 @@ oOf
 ahL
 aii
 aiL
-qoM
+kmN
 ajg
 ajP
 wLf
@@ -85269,7 +85272,7 @@ ahL
 sNS
 ajR
 bFP
-baD
+rrB
 bGT
 ulV
 akN
@@ -85523,7 +85526,7 @@ ntT
 apd
 iJJ
 ahL
-aij
+ggK
 bCg
 ewj
 ewj
@@ -85779,10 +85782,10 @@ aew
 iBg
 pah
 dfW
-eDM
+nwz
 bnC
 aiO
-drv
+qUZ
 ajj
 ajT
 akP
@@ -86857,7 +86860,7 @@ aVS
 aVS
 aVS
 aVS
-eaU
+baD
 bbW
 aVS
 aVS
@@ -87579,7 +87582,7 @@ rdI
 pXC
 pXC
 gyR
-xLx
+jiQ
 sbr
 agP
 ajp
@@ -88092,11 +88095,11 @@ upT
 wlO
 cnV
 cnV
-alx
-pxb
+qgK
+eIr
 oYQ
-alx
-cNR
+qgK
+glZ
 agP
 cCS
 alH
@@ -88349,10 +88352,10 @@ jda
 wlO
 cnV
 cnV
-alx
-uMv
-joe
-joe
+qgK
+pxb
+lBt
+lBt
 uNz
 aiR
 akT
@@ -88606,10 +88609,10 @@ jda
 wlO
 cnV
 cnV
-alx
-mKJ
-seY
-cYK
+qgK
+fVq
+tIf
+prm
 aiR
 aiR
 akU
@@ -88863,10 +88866,10 @@ jda
 fpQ
 kpN
 cnV
-alx
-uMv
-joe
-pTn
+qgK
+pxb
+lBt
+qbK
 aiR
 aka
 qeT
@@ -89120,10 +89123,10 @@ aXi
 rNN
 rNN
 rNN
-alx
-nUc
+qgK
+uMv
 uNz
-pTn
+qbK
 aiR
 akb
 akW
@@ -89377,7 +89380,7 @@ aig
 aic
 aic
 tTx
-alx
+qgK
 hpP
 hpP
 hpP
@@ -90987,7 +90990,7 @@ brg
 buh
 wQy
 bvo
-gen
+nJy
 byA
 bzZ
 bzZ
@@ -93089,7 +93092,7 @@ uoq
 tbj
 wYx
 tbj
-vNk
+vxg
 mZR
 nMP
 hQC
@@ -93346,8 +93349,8 @@ fyO
 snY
 ham
 cgT
-tCq
-oei
+lZY
+fRc
 uRk
 slC
 sWj
@@ -93564,9 +93567,9 @@ bsK
 bsK
 bsK
 xqq
-qQI
-ncr
-fym
+gru
+lur
+bxa
 bsK
 vlG
 bKG
@@ -93817,13 +93820,13 @@ qHa
 bpY
 brq
 bsK
-lpK
-wmr
-rdm
+aij
 gma
-ydL
-ydL
-dvc
+jGp
+frl
+rSF
+rSF
+brS
 bsK
 bLL
 bpY
@@ -93866,7 +93869,7 @@ uRk
 jMt
 sWj
 evB
-oCS
+iZq
 oIA
 rkp
 xNX
@@ -94078,9 +94081,9 @@ aYB
 bsK
 bsK
 xqq
-ydL
-ydL
-dvc
+rSF
+rSF
+brS
 bsK
 tal
 bpY
@@ -94331,13 +94334,13 @@ bja
 bpY
 qqX
 bsK
-iJL
-kBl
-xva
-pKC
-ydL
-ydL
-dvc
+nOQ
+rek
+eQn
+cVE
+rSF
+rSF
+brS
 bsK
 bMN
 bpY
@@ -94593,8 +94596,8 @@ bsK
 tcX
 xqq
 diT
-dIf
-nxF
+xQM
+sdp
 bsK
 bMN
 bpY
@@ -94848,7 +94851,7 @@ bsK
 bsK
 bsK
 bsK
-ile
+uoD
 bsK
 bsK
 bsK
@@ -97694,7 +97697,7 @@ bSP
 bSP
 qOx
 qOx
-rHV
+eqr
 ihJ
 gFX
 rdQ
@@ -102273,8 +102276,8 @@ aUw
 uxO
 xNS
 jOm
-hDh
-nmX
+lIs
+wrE
 hKm
 bbI
 bcC
@@ -102530,9 +102533,9 @@ anQ
 aVz
 aWz
 sLD
+uVo
 hzE
-baC
-baC
+hzE
 qXb
 udR
 dma
@@ -102786,8 +102789,8 @@ aTo
 aUx
 aVA
 qgE
-hJf
-ofn
+baC
+xEl
 aZr
 sql
 jbo
@@ -105355,7 +105358,7 @@ ueu
 bcV
 aSk
 sAD
-xmq
+jaC
 rAP
 cCB
 eJf
@@ -106383,7 +106386,7 @@ beR
 dyL
 saR
 uzV
-qYY
+igy
 wLu
 mBo
 gcb
@@ -106635,12 +106638,12 @@ nOV
 nOV
 nOV
 nOV
-uBG
+mqp
 nOV
 nOV
 ubj
 qEF
-uWy
+ydL
 aTy
 hOn
 dCB
@@ -106888,16 +106891,16 @@ qhh
 aEj
 aNV
 nOV
-lcB
-bgj
-kRv
-lVC
-eEa
-oMB
+fFG
+bCv
+hDh
+pXJ
+ucW
+alx
 nOV
 dUZ
-oEn
-jrX
+dXc
+qfC
 pvZ
 hUm
 tQp
@@ -107145,15 +107148,15 @@ aEj
 aEj
 aNW
 nOV
-rfX
-mqp
-kSu
-uIa
-gXu
+tOe
+pPZ
+knG
+bsS
+cZt
 tMk
-vxg
-fEC
-oEn
+vPh
+seY
+dXc
 baB
 pvZ
 tOw
@@ -107402,16 +107405,16 @@ aaa
 aEj
 aKr
 nOV
-rfX
-uSY
-qgK
-nju
-xPM
-vOi
-iCE
-fen
-cLU
-bPk
+tOe
+icY
+eOW
+uyk
+qId
+bay
+lRn
+ydr
+pOn
+gzw
 pvZ
 yeb
 iUS
@@ -107659,13 +107662,13 @@ aaa
 aEj
 aEj
 nOV
-faU
-tMb
-jyc
-igy
-eNz
-tLH
-xUQ
+nSG
+aou
+sAR
+dkk
+sXQ
+xxA
+cTI
 cCB
 szk
 cCB
@@ -107925,7 +107928,7 @@ aaa
 aYF
 vRk
 szk
-pQJ
+pAT
 pvZ
 aTy
 svW
@@ -108177,7 +108180,7 @@ aaa
 aaa
 aaa
 aaa
-bCv
+wmJ
 aaa
 aYF
 gfW

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2165,9 +2165,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "aij" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "aik" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron/dark,
@@ -4686,6 +4688,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/bridge)
+"aqL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/plating,
+/area/station/engineering/lobby)
 "aqY" = (
 /obj/item/cardboard_cutout,
 /obj/item/cardboard_cutout,
@@ -22347,9 +22354,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bCv" = (
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
 /turf/closed/wall/r_wall,
-/area/station/ai_monitored/security/armory)
+/area/station/security/tram)
 "bCx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
@@ -30729,6 +30735,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"cnP" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "cnT" = (
 /obj/machinery/vending/security,
 /turf/open/floor/iron/dark,
@@ -33581,6 +33591,12 @@
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
+"cKx" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "cKz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -34105,12 +34121,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"dlF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "dlS" = (
 /obj/structure/sign/warning/biohazard/directional/west,
 /obj/machinery/vending/drugs,
@@ -34164,6 +34174,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"dmW" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "dnM" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -35382,6 +35398,14 @@
 	},
 /turf/closed/wall,
 /area/station/commons/toilet/restrooms)
+"epY" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_lockdown";
+	name = "Chemistry Shutters"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "eqe" = (
 /obj/structure/rack,
 /obj/item/storage/backpack/satchel{
@@ -35739,12 +35763,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
-"eGv" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "eGD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
@@ -35902,9 +35920,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
-"eOc" = (
-/turf/closed/wall/r_wall,
-/area/station/security/tram)
 "eOe" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -36277,15 +36292,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"fdK" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "fdN" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -36999,6 +37005,15 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"fCf" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "fDg" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "IsolationCell";
@@ -37605,6 +37620,11 @@
 /obj/structure/railing/corner,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/secondary/entry)
+"fYI" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "fYZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/oxygen_output{
 	dir = 1
@@ -37631,6 +37651,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
+"gaq" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "gaF" = (
 /obj/machinery/button/door{
 	id = "prisonereducation";
@@ -37981,6 +38008,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"glz" = (
+/obj/machinery/incident_display/delam/directional/west,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "glE" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Drone Bay Maintenance"
@@ -38051,6 +38082,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"gnT" = (
+/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
+	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob"
+	},
+/turf/open/floor/plating,
+/area/station/security/tram)
 "gnX" = (
 /obj/structure/chair{
 	dir = 1
@@ -38446,12 +38483,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
-"gFj" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "gFo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 5
@@ -38510,11 +38541,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"gId" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "gIq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -38962,10 +38988,6 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"gYw" = (
-/obj/structure/table_frame,
-/turf/open/floor/wood/cold,
-/area/station/security/tram)
 "gYH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39376,6 +39398,11 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"hmS" = (
+/obj/structure/cable,
+/obj/structure/table_frame,
+/turf/open/floor/plating,
+/area/station/security/tram)
 "hng" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -39683,13 +39710,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/jadedragon)
-"hzK" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "hAK" = (
 /obj/structure/window/reinforced/spawner/directional/east{
 	layer = 2.9
@@ -39952,10 +39972,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"hIp" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "hIQ" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small/directional/west,
@@ -39994,12 +40010,6 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
-"hKI" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "hLr" = (
 /obj/machinery/air_sensor/oxygen_tank,
 /turf/open/floor/engine/o2,
@@ -40616,6 +40626,12 @@
 /obj/effect/decal/cleanable/glitter/blue,
 /turf/open/floor/glass,
 /area/station/service/jadedragon)
+"ifX" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "igd" = (
 /obj/structure/chair{
 	dir = 8
@@ -40765,14 +40781,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"ioO" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters{
-	id = "jangarage";
-	name = "Custodial Closet Shutters"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/tram)
 "ipH" = (
 /obj/effect/turf_decal/caution,
 /obj/effect/turf_decal/stripes/line{
@@ -40798,6 +40806,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"iqk" = (
+/obj/machinery/button/delam_scram,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "iqm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40943,6 +40955,9 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"ixz" = (
+/turf/open/floor/wood/cold,
+/area/station/security/tram)
 "ixN" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 5
@@ -41590,11 +41605,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"iVI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
 "iVJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -41602,6 +41612,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"iWF" = (
+/turf/closed/wall,
+/area/station/security/tram)
 "iWV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -42117,13 +42130,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"juE" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/rack,
-/obj/structure/cable,
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "juT" = (
 /obj/item/reagent_containers/cup/bucket,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -42810,6 +42816,10 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"jUH" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "jUP" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -42949,12 +42959,6 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"kbg" = (
-/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
-	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob"
-	},
-/turf/open/floor/plating,
-/area/station/security/tram)
 "kbu" = (
 /obj/machinery/door/airlock/command{
 	name = "External Access"
@@ -43176,6 +43180,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"koW" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/rack,
+/obj/structure/cable,
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "kpE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -43195,12 +43206,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
-"kqy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "kqH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -43548,6 +43553,10 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms)
+"kCw" = (
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/security/armory)
 "kCP" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -43852,9 +43861,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"kOJ" = (
-/turf/open/floor/plating,
-/area/station/security/tram)
 "kON" = (
 /obj/machinery/door/airlock/hatch{
 	name = "The Jade Dragon"
@@ -44095,6 +44101,11 @@
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"kVv" = (
+/obj/structure/cable,
+/obj/machinery/computer,
+/turf/open/floor/plating,
+/area/station/security/tram)
 "kVG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44555,6 +44566,10 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
+"lqk" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lqm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/button/door{
@@ -44873,14 +44888,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/science/ordnance)
-"lCx" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "lCK" = (
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
@@ -45143,14 +45150,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/bar)
-"lKv" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_lockdown";
-	name = "Chemistry Shutters"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "lKU" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -46209,10 +46208,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"mBj" = (
-/obj/machinery/incident_display/delam/directional/west,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
 "mBo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46411,6 +46406,10 @@
 "mKE" = (
 /turf/closed/wall,
 /area/station/medical/medbay/lobby)
+"mLl" = (
+/obj/structure/table_frame,
+/turf/open/floor/wood/cold,
+/area/station/security/tram)
 "mLv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -47454,12 +47453,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"nCW" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/rack,
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "nDn" = (
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -48087,6 +48080,15 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"nYS" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "jangarage";
+	name = "Custodial Closet Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/security/tram)
 "nZw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock{
@@ -48137,12 +48139,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
-"ocM" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "odc" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -48408,6 +48404,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
+"onu" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "onD" = (
 /obj/structure/table,
 /obj/effect/spawner/random/clothing/costume,
@@ -49087,6 +49091,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
+"oJu" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "oJx" = (
 /obj/machinery/light_switch{
 	pixel_x = 22;
@@ -49167,14 +49178,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet/restrooms)
-"oMB" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "oMH" = (
 /obj/structure/table,
 /obj/item/airlock_painter/decal,
@@ -49704,6 +49707,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"phy" = (
+/turf/open/floor/plating,
+/area/station/security/tram)
 "phC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -50314,12 +50320,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"pEx" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "pEL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -50764,6 +50764,12 @@
 /obj/structure/displaycase/forsale/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
+"pVv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "pVD" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
@@ -50955,13 +50961,6 @@
 /obj/structure/closet/secure_closet/barber,
 /turf/open/floor/wood,
 /area/station/service/barber)
-"qch" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "qcA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/plasticflaps/opaque,
@@ -51054,12 +51053,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qgK" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters{
+	id = "jangarage";
+	name = "Custodial Closet Shutters"
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/turf/open/floor/iron/dark,
+/area/station/security/tram)
 "qgM" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
@@ -51227,6 +51227,14 @@
 "qml" = (
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/blueshield)
+"qmB" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "qnJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -52016,15 +52024,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
-"qQt" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "qQD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52811,9 +52810,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"ruh" = (
-/turf/open/floor/wood/cold,
-/area/station/security/tram)
 "rui" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/machinery/light/small/directional/west,
@@ -53211,6 +53207,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"rIn" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "rIw" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -53473,6 +53478,12 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
+"rSN" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/rack,
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "rSQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -54499,10 +54510,6 @@
 /obj/effect/spawner/armory_spawn/microfusion,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"sOm" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "sOB" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -54636,6 +54643,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"sUI" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "sUP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55154,9 +55170,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"tkS" = (
-/turf/closed/wall,
-/area/station/security/tram)
 "tlc" = (
 /obj/machinery/recharger,
 /obj/structure/table,
@@ -55341,6 +55354,12 @@
 /obj/item/food/fishmeat,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"tra" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "try" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /turf/open/floor/iron,
@@ -56238,13 +56257,6 @@
 /obj/structure/bed,
 /turf/open/floor/wood,
 /area/station/service/barber)
-"ubD" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "ucn" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -57350,15 +57362,6 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
-"uTa" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	id = "jangarage";
-	name = "Custodial Closet Shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/security/tram)
 "uTi" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/cell_5k,
@@ -58461,6 +58464,13 @@
 "vHS" = (
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"vHT" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "vIa" = (
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark/side{
@@ -58611,6 +58621,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
+"vOx" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "vOB" = (
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
@@ -59353,15 +59370,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"wrR" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "wrU" = (
 /obj/machinery/photocopier,
 /obj/machinery/firealarm/directional/west,
@@ -59661,11 +59669,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"wDC" = (
-/obj/structure/cable,
-/obj/machinery/computer,
-/turf/open/floor/plating,
-/area/station/security/tram)
 "wDZ" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/qm)
@@ -60004,6 +60007,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine)
+"wNs" = (
+/obj/structure/sign/delam_procedure,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "wNI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -60497,6 +60504,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"xeR" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "xeZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61428,11 +61441,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"xOu" = (
-/obj/structure/cable,
-/obj/structure/table_frame,
-/turf/open/floor/plating,
-/area/station/security/tram)
 "xOC" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -61831,7 +61839,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "ydL" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "ydZ" = (
@@ -84481,7 +84489,7 @@ oOf
 ahL
 aii
 aiL
-nCW
+rSN
 ajg
 ajP
 wLf
@@ -84996,7 +85004,7 @@ ahL
 sNS
 ajR
 bFP
-gId
+fYI
 bGT
 ulV
 akN
@@ -85250,7 +85258,7 @@ ntT
 apd
 iJJ
 ahL
-oMB
+qmB
 bCg
 ewj
 ewj
@@ -85506,10 +85514,10 @@ aew
 iBg
 pah
 dfW
-bCv
+kCw
 bnC
 aiO
-juE
+koW
 ajj
 ajT
 akP
@@ -86584,7 +86592,7 @@ aVS
 aVS
 aVS
 aVS
-uTa
+nYS
 bbW
 aVS
 aVS
@@ -87306,7 +87314,7 @@ rdI
 pXC
 pXC
 gyR
-kqy
+aij
 sbr
 agP
 ajp
@@ -87819,11 +87827,11 @@ upT
 wlO
 cnV
 cnV
-eOc
-ioO
+bCv
+qgK
 oYQ
-eOc
-tkS
+bCv
+iWF
 agP
 cCS
 alH
@@ -88076,10 +88084,10 @@ jda
 wlO
 cnV
 cnV
-eOc
+bCv
 pxb
-kOJ
-kOJ
+phy
+phy
 uNz
 aiR
 akT
@@ -88333,10 +88341,10 @@ jda
 wlO
 cnV
 cnV
-eOc
-wDC
-kbg
-ruh
+bCv
+kVv
+gnT
+ixz
 aiR
 aiR
 akU
@@ -88590,10 +88598,10 @@ jda
 fpQ
 kpN
 cnV
-eOc
+bCv
 pxb
-kOJ
-gYw
+phy
+mLl
 aiR
 aka
 qeT
@@ -88847,10 +88855,10 @@ aXi
 rNN
 rNN
 rNN
-eOc
-xOu
+bCv
+hmS
 uNz
-gYw
+mLl
 aiR
 akb
 akW
@@ -89104,7 +89112,7 @@ aig
 aic
 aic
 tTx
-eOc
+bCv
 hpP
 hpP
 hpP
@@ -90714,7 +90722,7 @@ brg
 buh
 wQy
 bvo
-lKv
+epY
 byA
 bzZ
 bzZ
@@ -92816,7 +92824,7 @@ uoq
 tbj
 wYx
 tbj
-mBj
+glz
 mZR
 nMP
 hQC
@@ -93073,8 +93081,8 @@ fyO
 snY
 ham
 cgT
-uRk
-uRk
+wNs
+iqk
 uRk
 slC
 sWj
@@ -93291,9 +93299,9 @@ bsK
 bsK
 bsK
 xqq
-qgK
-wrR
-ubD
+vHT
+rIn
+oJu
 bsK
 vlG
 bKG
@@ -93544,13 +93552,13 @@ qHa
 bpY
 brq
 bsK
-aij
 ydL
-ocM
-lCx
-hIp
-hIp
-qch
+cnP
+cKx
+onu
+lqk
+lqk
+gaq
 bsK
 bLL
 bpY
@@ -93593,7 +93601,7 @@ uRk
 jMt
 sWj
 evB
-hzK
+vOx
 oIA
 rkp
 xNX
@@ -93801,13 +93809,13 @@ bun
 bpY
 cIe
 bsK
-sOm
+jUH
 bsK
 bsK
 xqq
-hIp
-hIp
-qch
+lqk
+lqk
+gaq
 bsK
 tal
 bpY
@@ -94058,13 +94066,13 @@ bja
 bpY
 qqX
 bsK
-gFj
-eGv
-pEx
-hKI
-hIp
-hIp
-qch
+xeR
+dmW
+tra
+ifX
+lqk
+lqk
+gaq
 bsK
 bMN
 bpY
@@ -94320,8 +94328,8 @@ bsK
 tcX
 xqq
 diT
-qQt
-fdK
+sUI
+fCf
 bsK
 bMN
 bpY
@@ -94575,7 +94583,7 @@ bsK
 bsK
 bsK
 bsK
-dlF
+pVv
 bsK
 bsK
 bsK
@@ -97421,7 +97429,7 @@ bSP
 bSP
 qOx
 qOx
-iVI
+aqL
 ihJ
 gFX
 rdQ

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1128,7 +1128,6 @@
 /obj/structure/bed/medical/emergency,
 /obj/structure/bed/medical/emergency,
 /obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
@@ -2166,12 +2165,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "aij" = (
-/obj/structure/lattice,
-/obj/machinery/camera/motion/directional/south{
-	c_tag = "Armory External"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "aik" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron/dark,
@@ -3913,6 +3909,7 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "anM" = (
@@ -18949,8 +18946,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bpQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/flora/bush/jungle/b/style_random,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/flora/grass/jungle,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
 /area/station/medical/paramedic)
 "bpR" = (
 /obj/effect/turf_decal/tile/blue{
@@ -20547,12 +20548,13 @@
 "bvm" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/shutters{
-	id = "plumbing_shutters";
-	name = "Plumbing Shutter"
-	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/white,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_lockdown";
+	name = "Chemistry Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/medical/chemistry)
 "bvo" = (
 /obj/structure/disposalpipe/segment{
@@ -20564,10 +20566,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bvp" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters";
-	name = "Chemistry Shutters"
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north{
 	dir = 2;
@@ -20576,6 +20574,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/yellow/filled,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_lockdown";
+	name = "Chemistry Shutters"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bvw" = (
@@ -21825,6 +21827,11 @@
 "bAh" = (
 /obj/machinery/chem_master,
 /obj/machinery/light/directional/north,
+/obj/machinery/button/door/directional/north{
+	id = "chem_lockdown";
+	name = "chemistry lockdown control";
+	req_access = list("pharmacy")
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bAi" = (
@@ -22340,9 +22347,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bCv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/security/armory)
 "bCx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
@@ -34049,9 +34056,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "diT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "djL" = (
@@ -34097,6 +34105,12 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"dlF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "dlS" = (
 /obj/structure/sign/warning/biohazard/directional/west,
 /obj/machinery/vending/drugs,
@@ -34964,7 +34978,7 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/grass/jungle,
-/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/grass,
 /area/station/medical/medbay/lobby)
 "dWp" = (
@@ -35725,6 +35739,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"eGv" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "eGD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
@@ -35882,6 +35902,9 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
+"eOc" = (
+/turf/closed/wall/r_wall,
+/area/station/security/tram)
 "eOe" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -36254,6 +36277,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"fdK" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "fdN" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -37617,10 +37649,10 @@
 /area/station/security/execution/education)
 "gaR" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/command/heads_quarters/blueshield)
 "gbu" = (
@@ -38269,6 +38301,7 @@
 "gyU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "gzv" = (
@@ -38413,6 +38446,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/surgery,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
+"gFj" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "gFo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 5
@@ -38471,6 +38510,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"gId" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "gIq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -38508,10 +38552,6 @@
 	name = "Atmospherics Lockdown Blast Door"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmoslock";
-	name = "Atmospherics Lockdown Blast Door"
-	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -38922,6 +38962,10 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"gYw" = (
+/obj/structure/table_frame,
+/turf/open/floor/wood/cold,
+/area/station/security/tram)
 "gYH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39381,7 +39425,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/security/office)
+/area/station/security/tram)
 "hpY" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39639,6 +39683,13 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/jadedragon)
+"hzK" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "hAK" = (
 /obj/structure/window/reinforced/spawner/directional/east{
 	layer = 2.9
@@ -39901,6 +39952,10 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"hIp" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "hIQ" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small/directional/west,
@@ -39939,6 +39994,12 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
+"hKI" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "hLr" = (
 /obj/machinery/air_sensor/oxygen_tank,
 /turf/open/floor/engine/o2,
@@ -40704,6 +40765,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
+"ioO" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters{
+	id = "jangarage";
+	name = "Custodial Closet Shutters"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/tram)
 "ipH" = (
 /obj/effect/turf_decal/caution,
 /obj/effect/turf_decal/stripes/line{
@@ -40711,7 +40780,6 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/engine_access,
-/obj/machinery/incident_display/delam/directional/west,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "iqc" = (
@@ -41522,6 +41590,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"iVI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/plating,
+/area/station/engineering/lobby)
 "iVJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42044,6 +42117,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"juE" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/rack,
+/obj/structure/cable,
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "juT" = (
 /obj/item/reagent_containers/cup/bucket,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -42869,6 +42949,12 @@
 /obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"kbg" = (
+/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
+	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob"
+	},
+/turf/open/floor/plating,
+/area/station/security/tram)
 "kbu" = (
 /obj/machinery/door/airlock/command{
 	name = "External Access"
@@ -43109,6 +43195,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
+"kqy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "kqH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -43760,6 +43852,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
+"kOJ" = (
+/turf/open/floor/plating,
+/area/station/security/tram)
 "kON" = (
 /obj/machinery/door/airlock/hatch{
 	name = "The Jade Dragon"
@@ -44778,6 +44873,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/science/ordnance)
+"lCx" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lCK" = (
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/burnchamber)
@@ -45040,6 +45143,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/bar)
+"lKv" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_lockdown";
+	name = "Chemistry Shutters"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lKU" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -45651,7 +45762,6 @@
 /area/station/medical/medbay/central)
 "mnQ" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
-/obj/structure/window/reinforced/tinted/spawner/directional/north,
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /turf/open/floor/wood/parquet,
 /area/station/service/jadedragon)
@@ -46099,6 +46209,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"mBj" = (
+/obj/machinery/incident_display/delam/directional/west,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "mBo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46182,6 +46296,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
 /turf/open/floor/iron/dark,
 /area/station/security/range)
 "mDW" = (
@@ -46501,10 +46616,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "mTf" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters";
-	name = "Chemistry Shutters"
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north{
 	dir = 2;
@@ -46512,6 +46623,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/yellow/filled,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_lockdown";
+	name = "Chemistry Shutters"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "mTo" = (
@@ -47339,6 +47454,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"nCW" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/rack,
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "nDn" = (
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -48016,6 +48137,12 @@
 	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
+"ocM" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "odc" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -49040,6 +49167,14 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet/restrooms)
+"oMB" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "oMH" = (
 /obj/structure/table,
 /obj/item/airlock_painter/decal,
@@ -49184,13 +49319,13 @@
 	req_one_access = list("pharmacy","chemistry")
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters";
-	name = "Chemistry Shutters"
-	},
 /obj/item/folder/white,
 /obj/item/pen,
 /obj/effect/turf_decal/trimline/yellow/filled,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_lockdown";
+	name = "Chemistry Shutters"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "oSc" = (
@@ -49379,11 +49514,12 @@
 /turf/closed/wall,
 /area/station/cargo/storage)
 "oYQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
+/obj/machinery/door/poddoor/shutters{
+	id = "jangarage";
+	name = "Custodial Closet Shutters"
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/tram)
 "oZv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -49846,7 +49982,6 @@
 /area/station/security/prison)
 "psC" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
-/obj/structure/window/reinforced/tinted/spawner/directional/north,
 /obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty{
 	pixel_x = 5
 	},
@@ -49927,8 +50062,8 @@
 /area/space/nearstation)
 "pxb" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
+/turf/open/floor/plating,
+/area/station/security/tram)
 "pxO" = (
 /obj/item/transfer_valve{
 	pixel_x = -5
@@ -50179,6 +50314,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"pEx" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "pEL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -50814,6 +50955,13 @@
 /obj/structure/closet/secure_closet/barber,
 /turf/open/floor/wood,
 /area/station/service/barber)
+"qch" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "qcA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/plasticflaps/opaque,
@@ -50827,10 +50975,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmoslock";
-	name = "Atmospherics Lockdown Blast Door"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
@@ -50910,10 +51054,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qgK" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/rack/gunrack,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "qgM" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
@@ -51870,6 +52016,15 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
+"qQt" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "qQD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52656,6 +52811,9 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"ruh" = (
+/turf/open/floor/wood/cold,
+/area/station/security/tram)
 "rui" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/machinery/light/small/directional/west,
@@ -54341,6 +54499,10 @@
 /obj/effect/spawner/armory_spawn/microfusion,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
+"sOm" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "sOB" = (
 /turf/closed/wall,
 /area/station/medical/psychology)
@@ -54992,6 +55154,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"tkS" = (
+/turf/closed/wall,
+/area/station/security/tram)
 "tlc" = (
 /obj/machinery/recharger,
 /obj/structure/table,
@@ -56073,6 +56238,13 @@
 /obj/structure/bed,
 /turf/open/floor/wood,
 /area/station/service/barber)
+"ubD" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ucn" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -57057,8 +57229,9 @@
 /turf/open/floor/wood,
 /area/station/security/prison)
 "uNz" = (
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/hos)
+/obj/structure/table_frame,
+/turf/open/floor/plating,
+/area/station/security/tram)
 "uOA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -57177,6 +57350,15 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
+"uTa" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "jangarage";
+	name = "Custodial Closet Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/security/tram)
 "uTi" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/cell_5k,
@@ -59171,6 +59353,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"wrR" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "wrU" = (
 /obj/machinery/photocopier,
 /obj/machinery/firealarm/directional/west,
@@ -59470,6 +59661,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"wDC" = (
+/obj/structure/cable,
+/obj/machinery/computer,
+/turf/open/floor/plating,
+/area/station/security/tram)
 "wDZ" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/qm)
@@ -60121,6 +60317,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "wZF" = (
@@ -61231,6 +61428,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"xOu" = (
+/obj/structure/cable,
+/obj/structure/table_frame,
+/turf/open/floor/plating,
+/area/station/security/tram)
 "xOC" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone"
@@ -61629,13 +61831,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "ydL" = (
-/obj/machinery/button/door{
-	id = "chemistry_shutters";
-	name = "Shutters Control";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_one_access = list("pharmacy","chemistry")
-	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "ydZ" = (
@@ -84021,11 +84217,11 @@ aem
 aen
 aen
 oex
-aaa
 aew
 aew
 aew
 aew
+ahL
 ahL
 ahL
 ahL
@@ -84278,7 +84474,6 @@ aaa
 aaa
 aby
 abI
-aht
 oqP
 aix
 aja
@@ -84286,6 +84481,7 @@ oOf
 ahL
 aii
 aiL
+nCW
 ajg
 ajP
 wLf
@@ -84535,7 +84731,6 @@ aaa
 aaa
 aby
 abI
-aht
 aew
 pKx
 fde
@@ -84543,6 +84738,7 @@ eFU
 ahL
 aiM
 boN
+jLN
 jLN
 ajQ
 akM
@@ -84792,7 +84988,6 @@ aaa
 aaa
 aby
 aht
-aij
 aew
 jKI
 xOd
@@ -84801,6 +84996,7 @@ ahL
 sNS
 ajR
 bFP
+gId
 bGT
 ulV
 akN
@@ -85049,14 +85245,14 @@ aaa
 aaa
 aby
 abI
-aht
 aew
 ntT
 apd
 iJJ
 ahL
-qgK
+oMB
 bCg
+ewj
 ewj
 ajS
 akO
@@ -85306,14 +85502,14 @@ aaa
 fon
 aby
 abI
-aht
 aew
 iBg
 pah
 dfW
-ahL
+bCv
 bnC
 aiO
+juE
 ajj
 ajT
 akP
@@ -85565,9 +85761,9 @@ abI
 aew
 aew
 aew
-aew
 uBg
 aew
+ahL
 ahL
 ahL
 ahL
@@ -85822,8 +86018,8 @@ aaa
 aew
 aik
 myx
-cnJ
 pah
+cnJ
 cnJ
 ahM
 ain
@@ -86388,7 +86584,7 @@ aVS
 aVS
 aVS
 aVS
-bbW
+uTa
 bbW
 aVS
 aVS
@@ -87110,7 +87306,7 @@ rdI
 pXC
 pXC
 gyR
-anM
+kqy
 sbr
 agP
 ajp
@@ -87623,11 +87819,11 @@ upT
 wlO
 cnV
 cnV
-gyR
-pxb
+eOc
+ioO
 oYQ
-gyR
-agP
+eOc
+tkS
 agP
 cCS
 alH
@@ -87880,10 +88076,10 @@ jda
 wlO
 cnV
 cnV
-gyR
+eOc
 pxb
-anM
-anM
+kOJ
+kOJ
 uNz
 aiR
 akT
@@ -88137,10 +88333,10 @@ jda
 wlO
 cnV
 cnV
-gyR
-pxb
-anM
-anM
+eOc
+wDC
+kbg
+ruh
 aiR
 aiR
 akU
@@ -88394,10 +88590,10 @@ jda
 fpQ
 kpN
 cnV
-gyR
+eOc
 pxb
-anM
-anM
+kOJ
+gYw
 aiR
 aka
 qeT
@@ -88651,10 +88847,10 @@ aXi
 rNN
 rNN
 rNN
-gyR
-pxb
-anM
-anM
+eOc
+xOu
+uNz
+gYw
 aiR
 akb
 akW
@@ -88908,7 +89104,7 @@ aig
 aic
 aic
 tTx
-gyR
+eOc
 hpP
 hpP
 hpP
@@ -90518,7 +90714,7 @@ brg
 buh
 wQy
 bvo
-qMC
+lKv
 byA
 bzZ
 bzZ
@@ -92061,7 +92257,7 @@ bsI
 tkl
 bwV
 mTf
-ydL
+bsK
 bsK
 bsK
 bEy
@@ -92324,9 +92520,9 @@ bBg
 bEy
 bsK
 rCo
-bsK
+tcX
 uIo
-bsK
+rlT
 bsK
 bsK
 foK
@@ -92620,7 +92816,7 @@ uoq
 tbj
 wYx
 tbj
-uRk
+mBj
 mZR
 nMP
 hQC
@@ -93095,9 +93291,9 @@ bsK
 bsK
 bsK
 xqq
-bsK
-bsK
-bsK
+qgK
+wrR
+ubD
 bsK
 vlG
 bKG
@@ -93348,13 +93544,13 @@ qHa
 bpY
 brq
 bsK
-bsK
-bsK
-bsK
-xqq
-bsK
-bsK
-bsK
+aij
+ydL
+ocM
+lCx
+hIp
+hIp
+qch
 bsK
 bLL
 bpY
@@ -93397,7 +93593,7 @@ uRk
 jMt
 sWj
 evB
-wZD
+hzK
 oIA
 rkp
 xNX
@@ -93605,13 +93801,13 @@ bun
 bpY
 cIe
 bsK
-bsK
+sOm
 bsK
 bsK
 xqq
-bsK
-bsK
-bsK
+hIp
+hIp
+qch
 bsK
 tal
 bpY
@@ -93862,13 +94058,13 @@ bja
 bpY
 qqX
 bsK
-bsK
-bsK
-bsK
-xqq
-bsK
-bsK
-bsK
+gFj
+eGv
+pEx
+hKI
+hIp
+hIp
+qch
 bsK
 bMN
 bpY
@@ -94119,13 +94315,13 @@ ccN
 bpY
 qqX
 bsK
-bCv
-hBd
-hBd
+bsK
+bsK
+tcX
 xqq
 diT
-bsK
-bsK
+qQt
+fdK
 bsK
 bMN
 bpY
@@ -94379,7 +94575,7 @@ bsK
 bsK
 bsK
 bsK
-bsK
+dlF
 bsK
 bsK
 bsK
@@ -97225,7 +97421,7 @@ bSP
 bSP
 qOx
 qOx
-gFX
+iVI
 ihJ
 gFX
 rdQ

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -183,7 +183,6 @@
 /area/station/command/heads_quarters/qm)
 "aaL" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "aaM" = (
@@ -1091,9 +1090,7 @@
 	id = "visitation";
 	name = "Visitation Shutters"
 	},
-/obj/machinery/door/window/right/directional/south{
-	dir = 4
-	},
+/obj/machinery/door/window/right/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/table,
 /turf/open/floor/iron,
@@ -1128,6 +1125,7 @@
 "aeE" = (
 /obj/structure/bed/medical/emergency,
 /obj/structure/bed/medical/emergency,
+/obj/machinery/iv_drip,
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -2166,9 +2164,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "aij" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/structure/lattice,
+/obj/machinery/camera/motion/directional/south{
+	c_tag = "Armory External"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "aik" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron/dark,
@@ -2547,10 +2548,8 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/photocopier,
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ajn" = (
@@ -2558,20 +2557,28 @@
 	pixel_y = 32
 	},
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 1
-	},
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ajo" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 1
+/obj/machinery/status_display/evac{
+	pixel_y = 32
 	},
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ajp" = (
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/machinery/photocopier,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
@@ -2725,17 +2732,17 @@
 /area/station/security/office)
 "aka" = (
 /obj/machinery/suit_storage_unit/hos,
-/obj/structure/sign/plaques/kiddie{
-	desc = "An embossed piece of paper from the University of Nanotrasen at Portpoint.";
-	name = "\improper 'Diploma' frame";
-	pixel_y = 32
-	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "akb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/cable,
+/obj/structure/sign/plaques/kiddie{
+	desc = "An embossed piece of paper from the University of Nanotrasen at Portpoint.";
+	name = "\improper 'Diploma' frame";
+	pixel_y = 32
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "akc" = (
@@ -2754,11 +2761,6 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/deputy,
-/obj/machinery/button/door/directional/north{
-	id = "secmechbay";
-	name = "Sec Mech Bay Shutters Control";
-	impact_sound = ssssss
-	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "ake" = (
@@ -2836,7 +2838,6 @@
 /area/station/maintenance/department/security/brig)
 "aks" = (
 /obj/machinery/light/small/directional/south,
-/mob/living/basic/cockroach/glockroach,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "akt" = (
@@ -2925,7 +2926,6 @@
 	name = "Evidence Closet"
 	},
 /obj/machinery/camera/autoname/directional/east,
-/obj/item/storage/box/donkpockets/donkpocketgondola,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "akM" = (
@@ -2985,7 +2985,6 @@
 /area/station/command/heads_quarters/hos)
 "akW" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "akZ" = (
@@ -3110,8 +3109,7 @@
 /turf/open/floor/iron/white,
 /area/station/security/brig)
 "alt" = (
-/obj/machinery/door/window/left/directional/west{
-	dir = 4;
+/obj/machinery/door/window/left/directional/east{
 	icon_state = "right";
 	name = "Brig Infirmary";
 	req_access = list("security")
@@ -3126,12 +3124,21 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "alx" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/effect/spawner/random/trash/food_packaging,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "aly" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3210,7 +3217,6 @@
 "alI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "alJ" = (
@@ -3299,8 +3305,7 @@
 /turf/open/floor/iron/white,
 /area/station/security/brig)
 "amc" = (
-/obj/machinery/door/window/left/directional/west{
-	dir = 4;
+/obj/machinery/door/window/left/directional/east{
 	icon_state = "right";
 	name = "Brig Infirmary";
 	req_access = list("security")
@@ -3617,9 +3622,8 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage/tech)
 "amK" = (
-/obj/machinery/door/window/right/directional/east{
+/obj/machinery/door/window/right/directional/north{
 	base_state = "left";
-	dir = 1;
 	icon_state = "left";
 	name = "Security Delivery";
 	req_access = list("security")
@@ -3904,7 +3908,6 @@
 /obj/structure/table,
 /obj/machinery/recharger,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/warden)
 "anM" = (
@@ -4052,22 +4055,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"aou" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/line,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/chair/office{
-	color = "#52B4E9";
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/station/bitrunning/den)
 "aov" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -4287,7 +4274,6 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 6
 	},
-/obj/machinery/requests_console/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "apg" = (
@@ -4438,8 +4424,7 @@
 /area/station/service/hydroponics)
 "apK" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
+/obj/machinery/door/window/brigdoor/left/directional/north{
 	name = "Armory Desk";
 	req_access = list("armory")
 	},
@@ -4745,12 +4730,17 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ark" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/ammo_workbench,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/chapel/dock)
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "arl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5252,7 +5242,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/item/storage/secure/safe/caps_spare/directional/east{
+/obj/structure/secure_safe/caps_spare/directional/east{
 	pixel_y = 10
 	},
 /turf/open/floor/iron/dark,
@@ -5371,7 +5361,7 @@
 /turf/open/floor/circuit/green,
 /area/station/maintenance/department/security/brig)
 "atw" = (
-/obj/machinery/door/window/brigdoor/security/cell{
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
 	id = "Cell 1";
 	name = "Cell 1"
 	},
@@ -5387,7 +5377,7 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/nt_rep)
 "atA" = (
-/obj/machinery/door/window/brigdoor/security/cell{
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
 	id = "Cell 2";
 	name = "Cell 2"
 	},
@@ -5398,7 +5388,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "atC" = (
-/obj/machinery/door/window/brigdoor/security/cell{
+/obj/machinery/door/window/brigdoor/security/cell/left/directional/south{
 	id = "Cell 3";
 	name = "Cell 3"
 	},
@@ -5794,8 +5784,7 @@
 /area/station/security/brig)
 "auD" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/east{
-	dir = 8;
+/obj/machinery/door/window/left/directional/west{
 	name = "Brig Desk";
 	req_access = list("security")
 	},
@@ -6123,8 +6112,7 @@
 /area/station/security/brig)
 "avC" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/east{
-	dir = 8;
+/obj/machinery/door/window/left/directional/west{
 	name = "Brig Desk";
 	req_access = list("security")
 	},
@@ -6591,9 +6579,8 @@
 /area/station/security/brig)
 "awO" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/south{
+/obj/machinery/door/window/left/directional/north{
 	base_state = "right";
-	dir = 1;
 	icon_state = "right";
 	name = "Brig Desk";
 	req_access = list("security")
@@ -6607,9 +6594,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "awP" = (
-/obj/machinery/door/window/left/directional/south{
+/obj/machinery/door/window/left/directional/north{
 	base_state = "right";
-	dir = 1;
 	icon_state = "right";
 	name = "Brig Desk";
 	req_access = list("security")
@@ -6633,9 +6619,8 @@
 	id = "Secure Gate";
 	name = "Brig Shutters"
 	},
-/obj/machinery/door/window/left/directional/south{
+/obj/machinery/door/window/left/directional/north{
 	base_state = "right";
-	dir = 1;
 	icon_state = "right";
 	name = "Brig Desk";
 	req_access = list("security")
@@ -7121,8 +7106,7 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain/private)
 "ayZ" = (
-/obj/machinery/door/window{
-	dir = 8;
+/obj/machinery/door/window/left/directional/west{
 	name = "Captain's Desk";
 	req_access = list("captain")
 	},
@@ -7137,7 +7121,7 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "azc" = (
-/obj/item/storage/secure/safe/directional/east{
+/obj/structure/secure_safe/directional/east{
 	pixel_y = 6
 	},
 /obj/machinery/light_switch/directional/east{
@@ -7459,14 +7443,13 @@
 /area/station/command/heads_quarters/captain/private)
 "aAx" = (
 /obj/structure/table/wood,
-/obj/machinery/door/window{
+/obj/machinery/door/window/left/directional/south{
 	name = "Captain's Desk";
 	req_access = list("captain")
 	},
 /obj/item/flashlight/lamp/green{
 	pixel_x = -9
 	},
-/obj/item/toy/captainsaid/collector,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "aAy" = (
@@ -7787,7 +7770,7 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aBz" = (
-/obj/item/storage/secure/safe/directional/west,
+/obj/structure/secure_safe/directional/west,
 /obj/structure/table/wood,
 /obj/item/paper_bin{
 	layer = 2.9
@@ -8646,9 +8629,7 @@
 	id = "visitation";
 	name = "Visitation Shutters"
 	},
-/obj/machinery/door/window/left/directional/south{
-	dir = 4
-	},
+/obj/machinery/door/window/left/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table,
 /turf/open/floor/iron,
@@ -8749,9 +8730,8 @@
 /obj/item/ai_module/core/full/asimov,
 /obj/effect/spawner/random/aimodule/harmless,
 /obj/item/ai_module/core/freeformcore,
-/obj/machinery/door/window{
+/obj/machinery/door/window/left/directional/east{
 	base_state = "right";
-	dir = 4;
 	icon_state = "right";
 	name = "Core Modules";
 	req_access = list("captain")
@@ -8805,8 +8785,7 @@
 /obj/structure/table,
 /obj/item/ai_module/supplied/oxygen,
 /obj/item/ai_module/zeroth/onehuman,
-/obj/machinery/door/window{
-	dir = 8;
+/obj/machinery/door/window/left/directional/west{
 	name = "High-Risk Modules";
 	req_access = list("captain")
 	},
@@ -9077,16 +9056,14 @@
 /area/station/command/heads_quarters/hop)
 "aFB" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/brigdoor{
+/obj/machinery/door/window/brigdoor/left/directional/north{
 	base_state = "rightsecure";
-	dir = 1;
 	icon_state = "rightsecure";
 	name = "Head of Personnel's Desk";
 	req_access = list("hop")
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/left/directional/north{
-	dir = 2;
+/obj/machinery/door/window/left/directional/south{
 	name = "Reception Window"
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -10797,8 +10774,7 @@
 /area/station/cargo/warehouse)
 "aMA" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/west{
-	dir = 1;
+/obj/machinery/door/window/left/directional/north{
 	name = "Comissary Desk";
 	req_access = list("cargo")
 	},
@@ -12477,8 +12453,7 @@
 	codes_txt = "delivery;dir=8";
 	location = "Kitchen"
 	},
-/obj/machinery/door/window/left/directional/south{
-	dir = 8;
+/obj/machinery/door/window/left/directional/west{
 	name = "Kitchen Delivery";
 	req_access = list("kitchen")
 	},
@@ -12940,11 +12915,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aUC" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/area/station/cargo/miningdock)
 "aUG" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -13920,17 +13898,11 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
 /obj/structure/closet/crate/internals,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aXA" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aXB" = (
@@ -13994,8 +13966,7 @@
 "aXJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/west{
-	dir = 2;
+/obj/machinery/door/window/right/directional/south{
 	name = "Security Checkpoint";
 	req_access = list("security")
 	},
@@ -14286,9 +14257,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aYB" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "aYE" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -14569,8 +14540,7 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/machinery/door/window/left/directional/west{
-	dir = 2;
+/obj/machinery/door/window/left/directional/south{
 	name = "Cargo Desk";
 	req_access = list("shipping")
 	},
@@ -14629,8 +14599,12 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "aZw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14924,13 +14898,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"bay" = (
-/obj/effect/landmark/start/bitrunner,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "baz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14962,31 +14929,40 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "baC" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "baD" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	id = "jangarage";
-	name = "Custodial Closet Shutters"
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/security/tram)
+/area/station/cargo/storage)
 "baE" = (
 /obj/machinery/light/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "baF" = (
 /obj/structure/table,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/item/clothing/gloves/cargo_gauntlet,
 /obj/item/clothing/gloves/cargo_gauntlet{
 	pixel_y = -3
@@ -15387,8 +15363,7 @@
 "bbV" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/west{
-	dir = 1;
+/obj/machinery/door/window/right/directional/north{
 	name = "Security Checkpoint";
 	req_access = list("security")
 	},
@@ -15449,9 +15424,8 @@
 "bcb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/right/directional/west{
+/obj/machinery/door/window/right/directional/north{
 	base_state = "left";
-	dir = 1;
 	icon_state = "left";
 	name = "Hydroponics Desk";
 	req_access = list("hydroponics")
@@ -15462,8 +15436,7 @@
 "bcc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/right/directional/west{
-	dir = 1;
+/obj/machinery/door/window/right/directional/north{
 	name = "Hydroponics Desk";
 	req_access = list("hydroponics")
 	},
@@ -15608,12 +15581,19 @@
 /turf/open/floor/iron,
 /area/station/service/bar)
 "bcB" = (
-/obj/structure/statue/petrified,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/item/radio/intercom{
+	pixel_x = -30
+	},
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/camera/autoname/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "bcC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15621,21 +15601,27 @@
 /turf/closed/wall,
 /area/station/cargo/miningdock)
 "bcE" = (
-/obj/structure/closet/wardrobe/miner,
+/obj/machinery/computer/order_console/mining,
 /obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bcF" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/computer/security/mining,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bcG" = (
-/obj/machinery/computer/security/mining,
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bcI" = (
@@ -15835,11 +15821,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bdM" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/requests_console{
-	department = "Mining";
-	pixel_x = 32
-	},
+/obj/effect/landmark/start/shaft_miner,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bdQ" = (
@@ -16192,10 +16176,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "beL" = (
-/obj/machinery/computer/order_console/mining,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "beM" = (
@@ -16214,8 +16195,14 @@
 /obj/structure/table,
 /obj/item/folder/yellow,
 /obj/item/pen,
-/obj/effect/turf_decal/trimline/brown/filled/end{
-	dir = 8
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/food/vendor_snacks/moth_bag{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = -8;
+	pixel_y = 9
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -16224,9 +16211,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "beR" = (
@@ -16405,14 +16391,13 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "bfB" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/firealarm/directional/west,
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
-/obj/item/stack/sheet/iron/fifty,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "bfC" = (
 /obj/structure/table,
 /obj/item/stack/sheet/cardboard,
@@ -16420,27 +16405,12 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "bfD" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/pickaxe{
-	pixel_x = 5
-	},
-/obj/item/shovel{
-	pixel_x = -5
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/closed/wall,
+/area/station/maintenance/department/science)
 "bfE" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/shaft_miner,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bfH" = (
@@ -16750,21 +16720,29 @@
 /area/station/science/robotics/mechbay)
 "bgK" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bgL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/shaft_miner,
+/obj/machinery/conveyor_switch/oneway{
+	id = "mining";
+	dir = 1;
+	pixel_y = 13
+	},
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bgM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/landmark/start/shaft_miner,
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bgS" = (
@@ -16928,20 +16906,24 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Maintenance"
+/obj/structure/cable,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/machinery/bouldertech/refinery/smelter,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "bhs" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bht" = (
@@ -16953,16 +16935,18 @@
 /area/station/cargo/miningdock)
 "bhu" = (
 /obj/machinery/light/directional/south,
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
 	},
+/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bhv" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+/obj/machinery/bouldertech/brm,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
@@ -17096,7 +17080,6 @@
 "biq" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "bir" = (
@@ -17180,11 +17163,11 @@
 /area/station/hallway/secondary/entry)
 "biK" = (
 /obj/machinery/airalarm/directional/south,
-/obj/item/storage/secure/safe{
+/obj/structure/secure_safe{
 	pixel_x = -27
 	},
-/obj/structure/closet/secure_closet/nanotrasen_consultant/station,
 /obj/item/clothing/under/rank/centcom/intern,
+/obj/structure/closet/secure_closet/nanotrasen_consultant,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
 "biM" = (
@@ -17585,9 +17568,8 @@
 /area/station/science/robotics/lab)
 "bkv" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/right/directional/east{
+/obj/machinery/door/window/right/directional/south{
 	base_state = "left";
-	dir = 2;
 	icon_state = "left";
 	name = "Robotics Desk";
 	req_access = list("robotics")
@@ -17627,9 +17609,8 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "bkD" = (
-/obj/machinery/door/window/right/directional/east{
+/obj/machinery/door/window/right/directional/south{
 	base_state = "left";
-	dir = 2;
 	icon_state = "left";
 	name = "Research Division Delivery";
 	req_access = list("science")
@@ -18959,12 +18940,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bpQ" = (
-/obj/structure/flora/bush/jungle/b/style_random,
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/flora/grass/jungle,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/grass,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/medical/paramedic)
 "bpR" = (
 /obj/effect/turf_decal/tile/blue{
@@ -19173,6 +19150,9 @@
 /area/station/science/research)
 "bqx" = (
 /obj/structure/table,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -19698,13 +19678,6 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
 /area/station/science/xenobiology)
-"brS" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "brT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -19771,9 +19744,8 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "bsb" = (
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	base_state = "right";
-	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #5";
 	req_access = list("xenobiology")
@@ -19783,9 +19755,8 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "bsd" = (
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	base_state = "right";
-	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #6"
 	},
@@ -19922,8 +19893,7 @@
 	dir = 8
 	},
 /obj/structure/table,
-/obj/machinery/door/window/right/directional/south{
-	dir = 1;
+/obj/machinery/door/window/right/directional/north{
 	name = "Medbay Front Desk";
 	req_access = list("medical")
 	},
@@ -20009,26 +19979,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
-"bsS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 7
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/corner{
-	dir = 1
-	},
-/obj/item/reagent_containers/cup/glass/coffee/colonial{
-	pixel_x = 8
-	},
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "bsT" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -20585,13 +20535,12 @@
 "bvm" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_lockdown";
-	name = "Chemistry Shutters"
+/obj/machinery/door/poddoor/shutters{
+	id = "plumbing_shutters";
+	name = "Plumbing Shutter"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bvo" = (
 /obj/structure/disposalpipe/segment{
@@ -20603,18 +20552,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bvp" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemistry_shutters";
+	name = "Chemistry Shutters"
+	},
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/north{
-	dir = 2;
+/obj/machinery/door/window/left/directional/south{
 	name = "Chemistry Desk";
 	req_one_access = list("pharmacy","chemistry")
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/yellow/filled,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_lockdown";
-	name = "Chemistry Shutters"
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bvw" = (
@@ -20963,13 +20911,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"bxa" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "bxd" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -21610,9 +21551,8 @@
 	id = "xenobio1";
 	name = "Containment Blast Door"
 	},
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	base_state = "right";
-	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #1";
 	req_access = list("xenobiology")
@@ -21671,9 +21611,8 @@
 	id = "xenobio3";
 	name = "Containment Blast Door"
 	},
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	base_state = "right";
-	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #3";
 	req_access = list("xenobiology")
@@ -21871,11 +21810,6 @@
 "bAh" = (
 /obj/machinery/chem_master,
 /obj/machinery/light/directional/north,
-/obj/machinery/button/door/directional/north{
-	id = "chem_lockdown";
-	name = "chemistry lockdown control";
-	req_access = list("pharmacy")
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bAi" = (
@@ -22360,7 +22294,7 @@
 /area/station/command/heads_quarters/cmo)
 "bCj" = (
 /obj/structure/bed/dogbed/runtime,
-/mob/living/simple_animal/pet/cat/runtime,
+/mob/living/basic/pet/cat/runtime,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "bCk" = (
@@ -22391,20 +22325,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bCv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/board_number/one{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/brown/line,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/engine,
-/area/station/bitrunning/den)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "bCx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
@@ -23048,7 +22971,6 @@
 /turf/open/floor/plating,
 /area/station/medical/surgery)
 "bFP" = (
-/mob/living/simple_animal/bot/cleanbot/autopatrol,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "bFS" = (
@@ -23186,8 +23108,14 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/dock)
 "bGG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west{
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	name = "Outlet Injector"
+	},
+/turf/open/floor/plating/airless,
 /area/station/service/chapel/dock)
 "bGH" = (
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -23346,19 +23274,20 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/dock)
 "bHL" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
+/turf/open/floor/plating,
+/area/station/service/chapel/dock)
 "bHM" = (
 /turf/closed/wall/r_wall,
 /area/station/service/chapel/dock)
 "bHN" = (
-/turf/open/floor/iron,
-/area/station/service/chapel/dock)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west{
+	layer = 2.9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bHP" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark,
@@ -23753,7 +23682,6 @@
 /area/space/nearstation)
 "bKa" = (
 /obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "bKc" = (
@@ -23765,7 +23693,6 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "bKe" = (
@@ -23782,9 +23709,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "bKh" = (
-/obj/machinery/door/window/right/directional/east{
+/obj/machinery/door/window/right/directional/west{
 	base_state = "left";
-	dir = 8;
 	icon_state = "left";
 	name = "Arena"
 	},
@@ -26743,7 +26669,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/item/toy/plush/skyrat/engihound,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "bUW" = (
@@ -26952,7 +26877,7 @@
 /obj/item/folder/yellow,
 /obj/item/paper/monitorkey,
 /obj/item/pen,
-/mob/living/simple_animal/parrot/poly,
+/mob/living/basic/parrot/poly,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -27539,14 +27464,11 @@
 	name = "Atmospherics Lockdown Blast Door"
 	},
 /obj/structure/cable,
-/obj/machinery/door/window/right/directional/west{
-	dir = 2;
+/obj/machinery/door/window/right/directional/south{
 	name = "Engineering Desk";
 	req_one_access = list("engineering")
 	},
-/obj/machinery/door/window/right/directional/east{
-	dir = 1
-	},
+/obj/machinery/door/window/right/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bXw" = (
@@ -29962,8 +29884,7 @@
 /area/station/service/chapel/monastery)
 "ckv" = (
 /obj/machinery/mass_driver/chapelgun,
-/obj/machinery/door/window/left/directional/east{
-	dir = 8;
+/obj/machinery/door/window/left/directional/west{
 	name = "Mass Driver"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32271,8 +32192,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "cvr" = (
-/obj/machinery/door/window/left/directional/east{
-	dir = 1;
+/obj/machinery/door/window/left/directional/north{
 	name = "Coffin Storage";
 	req_one_access = list("chapel_office")
 	},
@@ -32283,9 +32203,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "cvt" = (
-/obj/machinery/door/window/left/directional/east{
+/obj/machinery/door/window/left/directional/north{
 	base_state = "right";
-	dir = 1;
 	icon_state = "right";
 	name = "Coffin Storage";
 	req_one_access = list("chapel_office")
@@ -33126,9 +33045,8 @@
 /area/station/security/prison)
 "cAr" = (
 /obj/machinery/light/small/directional/west,
-/obj/machinery/door/window/right/directional/north{
+/obj/machinery/door/window/right/directional/south{
 	base_state = "left";
-	dir = 2;
 	icon_state = "left";
 	name = "Curator Desk Door";
 	req_access = list("chapel_office")
@@ -33205,8 +33123,7 @@
 /area/station/service/library)
 "cAy" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/door/window/right/directional/north{
-	dir = 2;
+/obj/machinery/door/window/right/directional/south{
 	name = "Curator Desk Door";
 	req_access = list("chapel_office")
 	},
@@ -33829,44 +33746,25 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"cTI" = (
-/obj/structure/table,
-/obj/item/food/ready_donk/mac_n_cheese{
-	pixel_y = 3;
-	pixel_x = 2
-	},
-/obj/item/food/ready_donk/nachos_grandes{
-	pixel_y = 7
-	},
-/obj/item/food/ready_donk/donkhiladas{
-	pixel_y = 11;
-	pixel_x = 1
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "cUr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/requests_console{
+	department = "Security";
+	pixel_x = 30
+	},
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 4
+	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "cVo" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"cVE" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "cVH" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room"
@@ -33939,14 +33837,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"cZt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "daB" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red{
@@ -34135,10 +34025,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "diT" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "djL" = (
@@ -34152,14 +34041,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
-"dkk" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/computer/order_console/bitrunning,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "dkn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -34203,11 +34084,16 @@
 /area/station/medical/medbay/central)
 "dma" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/radio/intercom{
-	pixel_x = -30
-	},
-/obj/machinery/camera/autoname/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table,
+/obj/item/food/vendor_snacks/rice_crackers{
+	pixel_y = 0;
+	pixel_x = 5
+	},
+/obj/effect/spawner/random/food_or_drink/any_snack_or_beverage{
+	pixel_x = -5;
+	pixel_y = 10
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "dmo" = (
@@ -34292,9 +34178,6 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/end{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -34980,9 +34863,8 @@
 	dir = 8;
 	id = "garbage"
 	},
-/obj/machinery/door/window/right/directional/east{
+/obj/machinery/door/window/right/directional/north{
 	base_state = "left";
-	dir = 1;
 	icon_state = "left";
 	name = "Danger: Conveyor Access";
 	req_access = list("supply")
@@ -35026,10 +34908,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "dUZ" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "dVp" = (
@@ -35065,7 +34944,7 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/grass/jungle,
-/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/station/medical/medbay/lobby)
 "dWp" = (
@@ -35091,12 +34970,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"dXc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "dXg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -35277,9 +35150,6 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 2
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ehM" = (
@@ -35371,8 +35241,7 @@
 "elc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/left/directional/west{
-	dir = 4;
+/obj/machinery/door/window/left/directional/east{
 	name = "Cargo Desk";
 	req_access = list("shipping")
 	},
@@ -35404,8 +35273,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
 "ema" = (
-/obj/machinery/door/window/left/directional/east{
-	dir = 1;
+/obj/machinery/door/window/left/directional/north{
 	name = "Medbay Delivery";
 	req_access = list("medical")
 	},
@@ -35506,11 +35374,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"eqr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
 "eqD" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -35893,23 +35756,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/crew_quarters/dorms)
-"eIr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/machinery/button/door/directional/north{
-	id = "secmechbay";
-	name = "Sec Mech Bay Shutters Control";
-	impact_sound = ssssss
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "secmechbay";
-	name = "Sec Mech Bay"
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "eIL" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -36029,12 +35875,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"eOW" = (
-/obj/machinery/computer/quantum_console{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/bitrunning/den)
 "eOZ" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/costume/judgerobe,
@@ -36061,12 +35901,6 @@
 /obj/item/reagent_containers/cup/glass/bottle/juice/smallcarton,
 /turf/open/floor/wood,
 /area/station/maintenance/department/crew_quarters/dorms)
-"eQn" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "eQL" = (
 /obj/structure/table,
 /obj/item/storage/fancy/egg_box,
@@ -36147,8 +35981,7 @@
 	name = "Morgue Waste Chute";
 	pixel_x = -7
 	},
-/obj/machinery/door/window/right/directional/south{
-	dir = 4;
+/obj/machinery/door/window/right/directional/east{
 	name = "Morgue Waste Chute"
 	},
 /obj/structure/disposalpipe/trunk{
@@ -36275,12 +36108,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"fak" = (
-/obj/structure/training_machine,
-/obj/effect/turf_decal/trimline/yellow,
-/obj/item/target/clown,
-/turf/open/floor/iron/dark,
-/area/station/security/range)
 "fal" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -36426,8 +36253,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "fdS" = (
-/obj/machinery/door/window/left/directional/south{
-	dir = 4;
+/obj/machinery/door/window/left/directional/east{
 	name = "Engineering Delivery";
 	req_access = list("engineering")
 	},
@@ -36584,7 +36410,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "fhM" = (
-/obj/item/storage/secure/safe{
+/obj/structure/secure_safe{
 	pixel_x = -22
 	},
 /obj/structure/disposalpipe/segment,
@@ -36789,14 +36615,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/service/jadedragon)
-"frl" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "frC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -37003,8 +36821,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/door/window/left/directional/east{
-	dir = 1;
+/obj/machinery/door/window/left/directional/north{
 	name = "Monkey Pen";
 	req_access = list("genetics")
 	},
@@ -37217,12 +37034,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"fFG" = (
-/obj/structure/sign/poster/contraband/random/directional/west,
-/obj/machinery/netpod,
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/bitrunning/den)
 "fFN" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -37410,6 +37221,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "fMp" = (
+/obj/machinery/light/directional/north,
 /obj/machinery/conveyor_switch/oneway{
 	id = "ShuttleLoad";
 	name = "Shuttle Load";
@@ -37421,7 +37233,6 @@
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "fMB" = (
@@ -37571,11 +37382,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/main)
-"fQP" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/hos)
 "fQT" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -37593,10 +37399,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"fRc" = (
-/obj/machinery/button/delam_scram,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
 "fSg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37643,26 +37445,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"fVq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "fVT" = (
 /obj/machinery/computer/security/telescreen/ordnance{
 	dir = 1;
 	pixel_y = -30
 	},
 /obj/structure/chair/office/light,
-/obj/item/toy/plush/skyrat/igneous_synth{
-	desc = "Stinky Synth Snoodl!";
-	name = "Dalton Snoodle"
-	},
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "fVY" = (
@@ -37804,10 +37592,10 @@
 /area/station/security/execution/education)
 "gaR" = (
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/command/heads_quarters/blueshield)
 "gbu" = (
@@ -37973,14 +37761,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"ggK" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "ggX" = (
 /obj/structure/table/wood/shuttle_bar,
 /obj/item/lipstick/random,
@@ -38152,21 +37932,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"glZ" = (
-/obj/machinery/door/airlock/security{
-	name = "Security Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/obj/effect/turf_decal/delivery/blue,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "gma" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/machinery/door/airlock/mining/glass{
+	name = "Comissary Back Room"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/maintenance/department/cargo)
 "gmA" = (
 /obj/item/trash/bee,
 /obj/machinery/hydroponics/soil,
@@ -38179,7 +37955,6 @@
 /obj/item/radio/intercom{
 	pixel_x = -28
 	},
-/mob/living/basic/garden_gnome,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "gmN" = (
@@ -38281,18 +38056,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"gru" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
-"grN" = (
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "grR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -38396,9 +38159,6 @@
 /mob/living/basic/sloth/paperwork{
 	name = "Taxes"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gvu" = (
@@ -38484,7 +38244,6 @@
 "gyU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "gzv" = (
@@ -38502,12 +38261,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
-"gzw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "gAG" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -38525,9 +38278,8 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/door/window{
+/obj/machinery/door/window/left/directional/east{
 	base_state = "right";
-	dir = 4;
 	icon_state = "right";
 	layer = 3
 	},
@@ -38730,18 +38482,19 @@
 	name = "Atmospherics Lockdown Blast Door"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Blast Door"
+	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/cell/high,
-/obj/machinery/door/window/right/directional/west{
-	dir = 2;
+/obj/machinery/door/window/right/directional/south{
 	name = "Engineering Desk";
 	req_one_access = list("engineering")
 	},
-/obj/machinery/door/window/right/directional/east{
-	dir = 1
-	},
+/obj/machinery/door/window/right/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "gKx" = (
@@ -38803,9 +38556,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"gMu" = (
-/turf/open/floor/plating,
-/area/space/nearstation)
 "gMG" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -39074,6 +38824,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"gVz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "gVA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/event_spawn,
@@ -39407,6 +39163,7 @@
 /area/station/security/prison)
 "hgV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "hhg" = (
@@ -39473,9 +39230,8 @@
 	id = "xenobio4";
 	name = "Containment Blast Door"
 	},
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	base_state = "right";
-	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #4";
 	req_access = list("xenobiology")
@@ -39553,6 +39309,14 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"hmJ" = (
+/obj/effect/landmark/start/shaft_miner,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "hng" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -39602,9 +39366,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
+/area/station/security/office)
 "hpY" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39651,15 +39413,6 @@
 /obj/item/reagent_containers/cup/glass/bottle/vodka,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
-"hsR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "hsS" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -39728,9 +39481,10 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
 "huJ" = (
+/obj/machinery/netpod,
 /obj/effect/decal/cleanable/robot_debris,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/cargo/bitrunning/den)
 "hvm" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/flora/bush/pointy/style_random,
@@ -39740,9 +39494,6 @@
 "hvF" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "hvW" = (
@@ -39863,6 +39614,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "hzF" = (
@@ -39903,9 +39656,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "hBR" = (
@@ -39979,14 +39729,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "hCT" = (
-/obj/machinery/door/window/brigdoor{
+/obj/machinery/door/window/brigdoor/left/directional/south{
 	name = "Justice Chamber";
 	req_access = list("armory")
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
+/obj/machinery/door/window/brigdoor/left/directional/north{
 	name = "Justice Chamber";
 	req_access = list("armory")
 	},
@@ -40006,11 +39755,20 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "hDh" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/west,
-/turf/open/floor/iron/stairs{
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/area/station/bitrunning/den)
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/holopad,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxiliary Base Construction"
@@ -40144,10 +39902,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "hKm" = (
-/obj/machinery/airalarm/directional/south,
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 4
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "hKz" = (
@@ -40305,11 +40063,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/burnchamber)
-"hPs" = (
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "hPI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -40728,21 +40481,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/theater)
-"icY" = (
-/obj/effect/landmark/start/bitrunner,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/board_number/three{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/line,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/station/bitrunning/den)
 "idj" = (
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -40818,14 +40556,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "igy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/machinery/computer/quantum_console,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark/smooth_corner,
+/area/station/cargo/bitrunning/den)
 "igC" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -40961,6 +40695,7 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/engine_access,
+/obj/machinery/incident_display/delam/directional/west,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "iqc" = (
@@ -41063,8 +40798,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "iuM" = (
-/obj/machinery/door/window/left/directional/south{
-	dir = 8;
+/obj/machinery/door/window/left/directional/west{
 	name = "Test Chamber";
 	req_access = list("xenobiology")
 	},
@@ -41124,10 +40858,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"ixx" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/station/service/bar)
 "ixN" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 5
@@ -41154,9 +40884,14 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ixW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/station/service/chapel/dock)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "ixY" = (
 /obj/structure/sink/directional/west,
 /obj/structure/cable,
@@ -41376,6 +41111,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"iHJ" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/statue/petrified,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "iHM" = (
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
@@ -41473,7 +41213,7 @@
 /area/station/medical/virology)
 "iJJ" = (
 /obj/structure/rack,
-/obj/item/vending_refill/security_peacekeeper,
+/obj/item/vending_refill/security,
 /obj/item/storage/box/handcuffs,
 /obj/item/storage/box/flashbangs{
 	pixel_x = -2;
@@ -41491,8 +41231,7 @@
 	icon_state = "right";
 	name = "Reception Window"
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 4;
+/obj/machinery/door/window/brigdoor/left/directional/east{
 	name = "Brig Control Desk"
 	},
 /turf/open/floor/iron,
@@ -41551,9 +41290,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "iMJ" = (
-/obj/machinery/light/broken,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/machinery/light/directional/south,
+/obj/machinery/byteforge,
+/obj/effect/turf_decal/box,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/bitrunning/den)
 "iNN" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/table,
@@ -41604,8 +41345,7 @@
 /area/station/medical/morgue)
 "iOw" = (
 /mob/living/basic/pet/dog/corgi,
-/obj/machinery/door/window/left/directional/east{
-	dir = 8;
+/obj/machinery/door/window/left/directional/west{
 	name = "Petting Garden"
 	},
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -41829,22 +41569,6 @@
 "iYT" = (
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
-"iZq" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
-"jaC" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "jaI" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -42040,15 +41764,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"jiQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "jjm" = (
 /obj/structure/cable,
 /obj/item/kirbyplants/organic/plant24{
@@ -42062,7 +41777,7 @@
 	pixel_x = -3;
 	pixel_y = 2
 	},
-/obj/item/storage/secure/briefcase{
+/obj/item/storage/briefcase/secure{
 	pixel_x = 2;
 	pixel_y = -2
 	},
@@ -42200,10 +41915,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"jph" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "jpt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/turf_decal/bot_blue,
@@ -42333,7 +42044,7 @@
 "jvs" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
-/area/station/maintenance/department/cargo)
+/area/station/cargo/bitrunning/den)
 "jvF" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8;
@@ -42400,10 +42111,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"jxH" = (
-/obj/item/virgin_mary,
-/turf/closed/wall,
-/area/station/service/chapel/monastery)
 "jxM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -42640,12 +42347,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/atmos/storage/gas)
-"jGp" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "jGt" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
@@ -42846,8 +42547,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "jOv" = (
+/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/machinery/modular_computer/preset/civilian,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "jOw" = (
@@ -43196,6 +42897,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/crew_quarters/dorms)
+"kew" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/pickaxe{
+	pixel_x = 5
+	},
+/obj/item/shovel{
+	pixel_x = -5
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "kex" = (
 /obj/item/aicard,
 /obj/item/circuitboard/aicore,
@@ -43344,22 +43062,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/auxlab)
-"kmN" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/rack,
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "knD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/executive,
 /area/station/commons/dorms/barracks)
-"knG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/byteforge,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/bitrunning/den)
 "knP" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plating,
@@ -43393,9 +43100,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "kpN" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/structure/training_machine,
+/obj/item/target/syndicate,
+/obj/effect/turf_decal/trimline/yellow,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "kpW" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable,
@@ -43580,6 +43289,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
+"kwD" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/requests_console{
+	department = "Mining";
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "kxj" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -43690,12 +43410,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
-"kBe" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "kBm" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -43921,17 +43635,7 @@
 /area/station/security/prison)
 "kHO" = (
 /obj/structure/bed/dogbed/renault,
-/mob/living/basic/pet/fox/renault{
-	icon_dead = "blue_dead_panda"s";
-	icon_living = "zest_panda";
-	icon_state = "zest_panda";
-	icon = 'modular_tannhauser/modules/Bestiary/art/mob/red_panda.dmi';
-	gender = "male";
-	light_color = "#00FF00";
-	light_range = 2;
-	speak_emote = list("chirps","huff-quacks")s);
-	name = "Zesty"
-	},
+/mob/living/basic/pet/fox/renault,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain/private)
 "kHP" = (
@@ -43969,12 +43673,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
-"kJG" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/landmark/secequipment,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "kKl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -44487,6 +44185,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/crew_quarters/dorms)
+"lcO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "lcP" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/misc/asteroid,
@@ -44807,9 +44520,7 @@
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
 "lqS" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/machinery/door/window/left/directional/east,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
@@ -44941,15 +44652,6 @@
 /obj/item/cigbutt/cigarbutt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"lur" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "lvr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
@@ -44986,8 +44688,7 @@
 /obj/item/stack/medical/gauze{
 	pixel_x = 2
 	},
-/obj/machinery/door/window/right/directional/south{
-	dir = 8;
+/obj/machinery/door/window/right/directional/west{
 	name = "Medbay Front Desk";
 	req_access = list("medical")
 	},
@@ -45067,18 +44768,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms/barracks)
-"lBt" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "lBG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/glass/reinforced,
@@ -45272,6 +44961,13 @@
 /obj/item/bedsheet/orange,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"lIb" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "lIr" = (
 /obj/item/shrapnel/bullet{
 	pixel_x = 7
@@ -45317,12 +45013,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
-"lIs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "lIu" = (
 /obj/machinery/shower/directional/east{
 	name = "emergency shower"
@@ -45495,13 +45185,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine)
-"lRn" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "lRS" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
@@ -45665,10 +45348,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
-"lZY" = (
-/obj/structure/sign/delam_procedure,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
 "mau" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
@@ -45838,9 +45517,8 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "mfu" = (
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	base_state = "right";
-	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #8";
 	req_access = list("xenobiology")
@@ -45939,7 +45617,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "mix" = (
-/obj/item/storage/secure/briefcase{
+/obj/item/storage/briefcase/secure{
 	pixel_x = 6;
 	pixel_y = 8
 	},
@@ -46005,6 +45683,7 @@
 /area/station/medical/medbay/central)
 "mnQ" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /turf/open/floor/wood/parquet,
 /area/station/service/jadedragon)
@@ -46068,10 +45747,10 @@
 /area/station/science/xenobiology)
 "mqp" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
 /turf/closed/wall,
-/area/station/bitrunning/den)
+/area/station/cargo/bitrunning/den)
 "mqD" = (
 /obj/machinery/cryopod{
 	dir = 8
@@ -46280,6 +45959,9 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"mxS" = (
+/turf/closed/wall,
+/area/space)
 "mxT" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -46530,12 +46212,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "mDL" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "mDW" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -46564,6 +46247,17 @@
 "mES" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
+"mET" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "mFu" = (
 /obj/machinery/light/dim/directional/east,
 /obj/structure/table/wood/fancy/purple,
@@ -46736,6 +46430,10 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
+"mOC" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "mOL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -46853,17 +46551,16 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "mTf" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemistry_shutters";
+	name = "Chemistry Shutters"
+	},
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/north{
-	dir = 2;
+/obj/machinery/door/window/left/directional/south{
 	name = "Chemistry Desk"
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/yellow/filled,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_lockdown";
-	name = "Chemistry Shutters"
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "mTo" = (
@@ -46955,6 +46652,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"mXg" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
+	},
+/obj/machinery/bouldertech/refinery,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "mXq" = (
 /obj/item/taperecorder,
 /obj/structure/table/wood,
@@ -46998,14 +46703,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"mXZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/range)
 "mYa" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -47420,11 +47117,35 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "noM" = (
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
+"npb" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/wardrobe/miner,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "nps" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/landmark/start/hangover/closet,
@@ -47489,9 +47210,7 @@
 /obj/structure/plasticflaps/opaque{
 	name = "Prisoner Transfer"
 	},
-/obj/machinery/door/window/brigdoor{
-	dir = 4
-	},
+/obj/machinery/door/window/brigdoor/left/directional/east,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison)
@@ -47546,14 +47265,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
-"nwz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/structure/table/rolling,
-/obj/item/toy/plush/skyrat/engihound,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
 "nwH" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Atmospherics Tank - Toxins";
@@ -47563,9 +47274,6 @@
 /area/station/engineering/atmos)
 "nxG" = (
 /obj/effect/landmark/start/cargo_technician,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "nxT" = (
@@ -47605,7 +47313,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
@@ -47613,9 +47321,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "nAS" = (
-/obj/item/toy/plush/skyrat/plushie_dan,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "nBt" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -47895,14 +47606,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/commons/dorms/barracks)
-"nJy" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_lockdown";
-	name = "Chemistry Shutters"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "nJH" = (
 /obj/structure/closet/wardrobe/white,
 /obj/effect/turf_decal/tile/neutral{
@@ -47956,15 +47659,6 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"nLS" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "nLU" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/machinery/light/directional/south,
@@ -48056,15 +47750,9 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/station/medical/storage)
-"nOQ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "nOV" = (
 /turf/closed/wall,
-/area/station/bitrunning/den)
+/area/station/cargo/bitrunning/den)
 "nOY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -48169,17 +47857,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
-"nSG" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 8
-	},
-/obj/item/kirbyplants/organic/plant7,
-/turf/open/floor/engine,
-/area/station/bitrunning/den)
 "nTn" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -48316,8 +47993,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "nXS" = (
-/obj/machinery/door/window/left/directional/east{
-	dir = 1;
+/obj/machinery/door/window/left/directional/north{
 	name = "Monkey Pen";
 	req_access = list("genetics")
 	},
@@ -49564,19 +49240,18 @@
 /area/station/maintenance/department/cargo)
 "oSa" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/north{
-	dir = 2;
+/obj/machinery/door/window/left/directional/south{
 	name = "Chemistry Desk";
 	req_one_access = list("pharmacy","chemistry")
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemistry_shutters";
+	name = "Chemistry Shutters"
+	},
 /obj/item/folder/white,
 /obj/item/pen,
 /obj/effect/turf_decal/trimline/yellow/filled,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_lockdown";
-	name = "Chemistry Shutters"
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "oSc" = (
@@ -49765,14 +49440,11 @@
 /turf/closed/wall,
 /area/station/cargo/storage)
 "oYQ" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "secmechbay";
-	name = "Sec Mech Bay"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
+/area/station/security/office)
 "oZv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -49792,16 +49464,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"oZN" = (
-/obj/structure/cable,
-/obj/machinery/mech_bay_recharge_port{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/circuit/red,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "oZP" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -49851,7 +49513,6 @@
 /obj/effect/turf_decal/trimline/green/line{
 	dir = 8
 	},
-/mob/living/basic/pet/bumbles,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "pbR" = (
@@ -50098,9 +49759,18 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/generic,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/landmark/start/bitrunner,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "pmc" = (
 /turf/closed/wall,
 /area/station/service/jadedragon)
@@ -50201,11 +49871,8 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
-"prm" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "prr" = (
+/obj/machinery/light/directional/south,
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
 	id = "ShuttleUnload";
@@ -50213,7 +49880,6 @@
 	pixel_x = 6;
 	pixel_y = 20
 	},
-/obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "prB" = (
@@ -50240,6 +49906,7 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/station/security/prison)
 "psC" = (
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
 /obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty{
 	pixel_x = 5
@@ -50320,16 +49987,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pxb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
+/area/station/security/office)
 "pxO" = (
 /obj/item/transfer_valve{
 	pixel_x = -5
@@ -50365,8 +50025,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "pzn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/entertainment/deck,
+/obj/structure/table,
+/obj/effect/spawner/random/entertainment/cigarette_pack{
+	pixel_x = -6;
+	pixel_y = 8
+	},
+/obj/item/storage/box/bandages{
+	pixel_y = 6;
+	pixel_x = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "pzt" = (
@@ -50449,38 +50119,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"pAO" = (
-/obj/structure/table,
-/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
-	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob";
-	pixel_y = 9;
-	pixel_x = -10
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "pAR" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"pAT" = (
-/obj/structure/sign/warning/vacuum/external/directional/south,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "pAX" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral{
@@ -50718,8 +50362,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/door/window/right/directional/east{
-	dir = 1;
+/obj/machinery/door/window/right/directional/north{
 	name = "Atmospherics Delivery";
 	req_access = list("atmospherics")
 	},
@@ -50779,6 +50422,14 @@
 /obj/effect/turf_decal/trimline/dark_blue/line,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"pKK" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "pKT" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
@@ -50895,12 +50546,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"pOn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "pOr" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -50941,8 +50586,8 @@
 /obj/item/reagent_containers/cup/soda_cans/space_mountain_wind{
 	pixel_x = 5
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/cargo/bitrunning/den)
 "pPI" = (
 /obj/structure/table,
 /obj/machinery/camera/directional/north{
@@ -50972,22 +50617,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
-"pPZ" = (
-/obj/effect/landmark/start/bitrunner,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/board_number/two{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/trimline/brown/line,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/station/bitrunning/den)
 "pQb" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Atmospherics Tank - Air";
@@ -51088,8 +50717,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmospherics_engine)
 "pWm" = (
-/obj/machinery/door/window/left/directional/south{
-	dir = 4;
+/obj/machinery/door/window/left/directional/east{
 	name = "Test Chamber";
 	req_access = list("xenobiology")
 	},
@@ -51141,17 +50769,6 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"pXJ" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "pXT" = (
 /obj/item/kirbyplants,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -51267,13 +50884,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"qbK" = (
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "qbZ" = (
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -51294,6 +50904,10 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmoslock";
+	name = "Atmospherics Lockdown Blast Door"
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
@@ -51339,20 +50953,12 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "qeT" = (
-/obj/item/storage/secure/safe/hos{
+/obj/structure/secure_safe/hos{
 	pixel_x = -24;
 	pixel_y = 27
 	},
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
-"qfC" = (
-/obj/machinery/light/floor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "qgw" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -51381,15 +50987,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qgK" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/mapping_helpers/apc/cell_5k,
-/obj/structure/cable,
-/obj/machinery/mechpad,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/rack/gunrack,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
+/area/station/ai_monitored/security/armory)
 "qgM" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
@@ -52077,7 +51678,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "qEM" = (
@@ -52144,16 +51744,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"qId" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/landmark/start/bitrunner,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "qIl" = (
 /obj/machinery/computer/pandemic,
 /obj/machinery/airalarm/directional/north,
@@ -52469,13 +52059,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"qUZ" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/rack,
-/obj/structure/cable,
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "qVb" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/blueshield)
@@ -52603,6 +52186,13 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"raZ" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "rbo" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -52636,11 +52226,14 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "rcV" = (
-/obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/security/range)
+/area/station/security/office)
 "rdn" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/engineering_welding,
@@ -52662,12 +52255,6 @@
 "rdQ" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/storage/gas)
-"rek" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "reH" = (
 /obj/item/reagent_containers/cup/glass/bottle/vodka,
 /obj/structure/disposalpipe/segment{
@@ -53040,11 +52627,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
-"rrB" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "rrU" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -53232,10 +52814,11 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
 "rxv" = (
+/obj/machinery/netpod,
 /obj/structure/sign/poster/random/directional/north,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/cargo/bitrunning/den)
 "rxA" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -53356,9 +52939,6 @@
 /obj/machinery/light_switch{
 	pixel_x = 25;
 	pixel_y = -9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -53512,12 +53092,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms/barracks)
-"rGp" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "rGq" = (
 /obj/item/kirbyplants/organic/plant18,
 /obj/effect/turf_decal/tile/neutral{
@@ -53627,6 +53201,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/dark_blue/corner{
+	dir = 4
+	},
 /obj/item/reagent_containers/cup/glass/bottle/whiskey{
 	pixel_x = -9;
 	pixel_y = 1
@@ -53817,10 +53394,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
-"rSF" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "rSH" = (
 /obj/item/trash/can,
 /obj/effect/landmark/generic_maintenance_landmark,
@@ -53837,7 +53410,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "rTD" = (
@@ -53998,9 +53570,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "sbI" = (
@@ -54090,15 +53659,6 @@
 /obj/item/key/security,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
-"sdp" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "sdZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrogen_output{
 	dir = 1
@@ -54126,14 +53686,12 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "seY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 1
+/obj/machinery/quantum_server,
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/area/station/cargo/bitrunning/den)
 "sfo" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -54300,9 +53858,8 @@
 /turf/open/floor/iron/dark/airless,
 /area/station/science/ordnance/freezerchamber)
 "smW" = (
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	base_state = "right";
-	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #7";
 	req_access = list("xenobiology")
@@ -54518,8 +54075,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "syq" = (
-/obj/machinery/door/window/left/directional/west{
-	dir = 1;
+/obj/machinery/door/window/left/directional/north{
 	name = "Gas Ports"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
@@ -54592,11 +54148,6 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"sAR" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/machinery/quantum_server,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/bitrunning/den)
 "sBf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -54836,6 +54387,7 @@
 /area/station/medical/paramedic)
 "sLD" = (
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -54969,9 +54521,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"sSz" = (
-/turf/open/space/basic,
-/area/station/command/bridge)
 "sSE" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/engine,
@@ -55115,26 +54664,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"sXQ" = (
-/obj/structure/table,
-/obj/item/food/cornchips/blue{
-	pixel_x = 9;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/cup/soda_cans/space_mountain_wind{
-	pixel_x = -7;
-	pixel_y = -1
-	},
-/obj/item/food/cornchips/red{
-	pixel_x = 3;
-	pixel_y = 6
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "sXR" = (
 /obj/structure/disposalpipe/junction,
 /turf/closed/wall/r_wall,
@@ -55281,6 +54810,9 @@
 "tbD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
@@ -55736,14 +55268,6 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
-"tsk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/item/toy/plush/skyrat/derg_plushie,
-/obj/structure/table/wood,
-/turf/open/floor/iron/white,
-/area/station/medical/psychology)
 "ttB" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -55857,6 +55381,17 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"twZ" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/structure/railing/corner/end,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/rubble,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "txB" = (
 /obj/structure/bookcase/random/adult,
 /obj/machinery/light/small/directional/south,
@@ -56034,12 +55569,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/station/engineering/atmospherics_engine)
-"tFe" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
-	},
-/turf/open/floor/iron,
-/area/station/service/chapel/dock)
 "tFt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/painting/library_private{
@@ -56109,15 +55638,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
-"tIf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "tIl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -56199,12 +55719,11 @@
 /turf/closed/wall,
 /area/station/cargo/sorting)
 "tMk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/warning,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
+/obj/item/toy/plush/moth{
+	name = "Wereni Moff"
+	},
+/turf/open/space/basic,
+/area/space)
 "tMs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -56282,11 +55801,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
-"tOe" = (
-/obj/machinery/netpod,
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/bitrunning/den)
 "tOf" = (
 /obj/structure/sign/poster/random/directional/north,
 /obj/machinery/conveyor_switch/oneway{
@@ -56672,14 +56186,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"ucW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/west,
-/obj/effect/landmark/start/bitrunner,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "udk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -56709,6 +56215,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "uek" = (
@@ -56869,8 +56378,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/window/right/directional/south{
-	dir = 8;
+/obj/machinery/door/window/right/directional/west{
 	name = "Medbay Front Desk";
 	req_access = list("medical")
 	},
@@ -57033,12 +56541,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/ordnance_storage,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
-"uoD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "uoS" = (
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
@@ -57302,17 +56804,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
-"uyk" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/item/modular_computer/laptop/preset/civilian{
-	pixel_y = 5;
-	pixel_x = 2
-	},
-/obj/structure/table,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "uyy" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -57378,9 +56869,6 @@
 /area/station/cargo/storage)
 "uzX" = (
 /obj/machinery/light/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "uAh" = (
@@ -57446,8 +56934,9 @@
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "uDp" = (
-/obj/item/toy/plush/moth{
-	name = "Wereni Moff"
+/obj/item/toy/plush/skyrat/igneous_synth{
+	desc = "Stinky Synth Snoodl!";
+	name = "Dalton Snoodle"
 	},
 /turf/open/misc/asteroid/airless,
 /area/station/science/ordnance/bomb)
@@ -57642,13 +57131,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "uMv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "uMY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -57665,17 +57152,8 @@
 /turf/open/floor/wood,
 /area/station/security/prison)
 "uNz" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
+/area/station/command/heads_quarters/hos)
 "uOA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -57817,10 +57295,19 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/station/maintenance/department/cargo)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/station/cargo/bitrunning/den)
 "uUr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -57857,16 +57344,6 @@
 /obj/item/stamp/law,
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
-"uVo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "uVt" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
@@ -57885,12 +57362,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"uXi" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/west,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/landmark/secequipment,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "uXE" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
@@ -58475,9 +57946,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "vqE" = (
@@ -58501,11 +57969,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
-"vrq" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "vrr" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 4;
@@ -58646,15 +58109,6 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"vvm" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "vvD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58721,9 +58175,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "vxg" = (
-/obj/machinery/incident_display/delam/directional/west,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/closed/wall,
+/area/station/cargo/storage)
 "vxp" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
@@ -59090,18 +58546,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"vPh" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Comissary Back Room"
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "vPE" = (
 /obj/structure/chair/office/light,
 /obj/effect/turf_decal/tile/blue{
@@ -59140,15 +58584,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"vPZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 5
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "vQo" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Office Maintenance"
@@ -59311,7 +58746,7 @@
 /area/station/commons/storage/tools)
 "vTN" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/window/brigdoor{
+/obj/machinery/door/window/brigdoor/left/directional/south{
 	name = "Test Range"
 	},
 /turf/open/floor/iron,
@@ -59371,8 +58806,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "vZP" = (
-/obj/machinery/door/window/left/directional/west{
-	dir = 1;
+/obj/machinery/door/window/left/directional/north{
 	name = "Returns";
 	pixel_y = 7;
 	req_access = list("shipping")
@@ -59397,12 +58831,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "waf" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Equipment Room"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/delivery/blue,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "way" = (
@@ -59741,16 +59178,6 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space)
-"wmJ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/toy/plush/moth{
-	name = "Wereni Moff"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "wns" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plating,
@@ -59797,21 +59224,6 @@
 /obj/item/pestle,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
-"wpr" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/ammo_workbench,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/range)
 "wpE" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/dark,
@@ -59853,10 +59265,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"wrE" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "wrU" = (
 /obj/machinery/photocopier,
 /obj/machinery/firealarm/directional/west,
@@ -60234,8 +59642,7 @@
 /area/station/hallway/secondary/entry)
 "wGh" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/west{
-	dir = 4;
+/obj/machinery/door/window/left/directional/east{
 	name = "Comissary Desk";
 	req_access = list("cargo")
 	},
@@ -60652,6 +60059,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
+"wRW" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "wTz" = (
 /turf/closed/wall,
 /area/station/engineering/atmos)
@@ -60807,7 +60220,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "wZF" = (
@@ -60912,20 +60324,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"xdp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "xdx" = (
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
@@ -61294,14 +60692,11 @@
 	name = "Atmospherics Lockdown Blast Door"
 	},
 /obj/structure/cable,
-/obj/machinery/door/window/right/directional/west{
-	dir = 2;
+/obj/machinery/door/window/right/directional/south{
 	name = "Atmospherics Desk";
 	req_access = list("atmospherics")
 	},
-/obj/machinery/door/window/right/directional/east{
-	dir = 1
-	},
+/obj/machinery/door/window/right/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
 "xpn" = (
@@ -61484,13 +60879,6 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"xxA" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/machinery/light/small/directional/east,
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/carpet/neon/simple/black/nodots,
-/area/station/bitrunning/den)
 "xxC" = (
 /obj/machinery/door/poddoor{
 	id = "SecJusticeChamber";
@@ -61506,9 +60894,8 @@
 	id = "xenobio2";
 	name = "Containment Blast Door"
 	},
-/obj/machinery/door/window/left/directional/north{
+/obj/machinery/door/window/left/directional/south{
 	base_state = "right";
-	dir = 2;
 	icon_state = "right";
 	name = "Containment Pen #2";
 	req_access = list("xenobiology")
@@ -61609,8 +60996,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/auxlab)
 "xBe" = (
-/obj/machinery/door/window/right/directional/north{
-	dir = 2;
+/obj/machinery/door/window/right/directional/south{
 	name = "Ordnance Freezer Chamber Access";
 	req_access = list("ordnance")
 	},
@@ -61625,14 +61011,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"xBO" = (
-/obj/structure/cable,
-/obj/machinery/computer/mech_bay_power_console,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/circuit/red,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "xCm" = (
 /obj/structure/closet/wardrobe/green,
 /turf/open/floor/iron/dark,
@@ -61682,16 +61060,6 @@
 /obj/machinery/computer/shuttle/arrivals/recall,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"xEl" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "xEt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -62050,15 +61418,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
-"xQM" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "xQO" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -62289,6 +61648,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
+"yaE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/conveyor{
+	dir = 9;
+	id = "mining"
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "yba" = (
 /obj/machinery/light/small/broken/directional/south,
 /obj/structure/cable,
@@ -62363,20 +61734,16 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"ydr" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "ydL" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/button/door{
+	id = "chemistry_shutters";
+	name = "Shutters Control";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_one_access = list("pharmacy","chemistry")
 	},
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ydZ" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -62460,13 +61827,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"yhJ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/recharge_floor,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "yhV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -62548,6 +61908,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"ykJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "ylb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -75120,7 +74489,7 @@ kcx
 cfN
 cfN
 cfN
-jxH
+bWV
 bXJ
 cve
 cuK
@@ -75855,7 +75224,7 @@ aaa
 aaa
 aaa
 aaa
-maV
+aaa
 aaa
 aaa
 aaa
@@ -76886,7 +76255,7 @@ aaa
 aaa
 aaa
 aaa
-gMu
+emV
 bGF
 bHJ
 pbm
@@ -77143,7 +76512,7 @@ aaa
 aaa
 aaa
 aaa
-bNw
+aaa
 bGE
 bGE
 bIV
@@ -77399,10 +76768,10 @@ aaa
 aaa
 aaa
 aaa
-mVM
-ixW
+aaa
+aaa
 bGG
-bGG
+bHL
 aHE
 bKc
 eVb
@@ -77657,9 +77026,9 @@ hXW
 hXW
 hXW
 hXW
-bNw
-bGG
-bHN
+aaa
+bGH
+bGE
 cqI
 bKd
 bLp
@@ -77912,11 +77281,11 @@ aht
 bns
 bbU
 tow
-baK
-baK
-tFe
-bGG
-bHN
+aHy
+hXW
+aaa
+bGI
+bHM
 bHM
 bHM
 bLq
@@ -78169,10 +77538,10 @@ aht
 aZx
 bbU
 baK
-bdZ
-bdZ
-ark
-bGG
+aHy
+hXW
+aaa
+aaa
 bHN
 bGE
 bKe
@@ -78426,11 +77795,11 @@ aZx
 aZx
 bbU
 baK
-eMM
+aHy
 hXW
-bNw
-bNw
-bNw
+aaa
+aaa
+bGI
 bGE
 bKf
 aHM
@@ -78683,7 +78052,7 @@ cKI
 ryi
 bbU
 baK
-eMM
+aHy
 hXW
 aaa
 aaa
@@ -78940,8 +78309,8 @@ aZx
 aZx
 bbU
 baK
-eMM
-aZx
+nAS
+hXW
 aaa
 aaa
 bGI
@@ -79196,9 +78565,9 @@ aZx
 pCe
 bbU
 vrJ
-bea
+baK
 sGO
-aZx
+hXW
 aaa
 aaa
 aaa
@@ -79453,9 +78822,9 @@ aZx
 xDY
 bbU
 baK
-iVx
+baK
 eMM
-aZx
+hXW
 aaa
 aaa
 aaa
@@ -79709,10 +79078,10 @@ aaa
 aZx
 fUx
 bbU
-baK
+bdY
 bdW
 ybs
-aZx
+hXW
 aaa
 aaa
 aaa
@@ -79969,7 +79338,7 @@ bbU
 baK
 irU
 eMM
-aZx
+hXW
 aaa
 aaa
 aaa
@@ -80226,7 +79595,7 @@ bbU
 bbU
 irU
 eMM
-aZx
+hXW
 aaa
 aaa
 aaa
@@ -80485,7 +79854,7 @@ irU
 eMM
 aZx
 aaa
-aaa
+maV
 aaa
 jCF
 aaa
@@ -84767,11 +84136,11 @@ aem
 aen
 aen
 oex
+aaa
 aew
 aew
 aew
 aew
-ahL
 ahL
 ahL
 ahL
@@ -85024,6 +84393,7 @@ aaa
 aaa
 aby
 abI
+aht
 oqP
 aix
 aja
@@ -85031,7 +84401,6 @@ oOf
 ahL
 aii
 aiL
-kmN
 ajg
 ajP
 wLf
@@ -85281,6 +84650,7 @@ aaa
 aaa
 aby
 abI
+aht
 aew
 pKx
 fde
@@ -85288,7 +84658,6 @@ eFU
 ahL
 aiM
 boN
-jLN
 jLN
 ajQ
 akM
@@ -85538,6 +84907,7 @@ aaa
 aaa
 aby
 aht
+aij
 aew
 jKI
 xOd
@@ -85546,7 +84916,6 @@ ahL
 sNS
 ajR
 bFP
-rrB
 bGT
 ulV
 akN
@@ -85795,14 +85164,14 @@ aaa
 aaa
 aby
 abI
+aht
 aew
 ntT
 apd
 iJJ
 ahL
-ggK
+qgK
 bCg
-ewj
 ewj
 ajS
 akO
@@ -86052,6 +85421,7 @@ aaa
 fon
 aby
 abI
+aht
 aew
 iBg
 pah
@@ -86059,7 +85429,6 @@ dfW
 ahL
 bnC
 aiO
-qUZ
 ajj
 ajT
 akP
@@ -86311,9 +85680,9 @@ abI
 aew
 aew
 aew
+aew
 uBg
 aew
-ahL
 ahL
 ahL
 ahL
@@ -86568,8 +85937,8 @@ aaa
 aew
 aik
 myx
-pah
 cnJ
+pah
 cnJ
 ahM
 ain
@@ -87076,7 +86445,7 @@ aaa
 aaa
 aaa
 aaa
-gYo
+aaa
 aby
 aaa
 aew
@@ -87089,7 +86458,7 @@ cnJ
 nrx
 qwn
 ajm
-gyU
+ixW
 anM
 alD
 amo
@@ -87134,7 +86503,7 @@ aVS
 aVS
 aVS
 aVS
-baD
+bbW
 bbW
 aVS
 aVS
@@ -87333,6 +86702,7 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aby
 aht
 aew
@@ -87343,10 +86713,9 @@ aew
 aew
 aew
 aew
-aew
 qwn
 ajn
-gyU
+ixW
 qTO
 feH
 amp
@@ -87590,6 +86959,7 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aby
 aaa
 aic
@@ -87599,9 +86969,8 @@ cnN
 cnV
 gyR
 tuJ
-uXi
-kJG
-grN
+anM
+agP
 ajo
 tbD
 dhu
@@ -87847,20 +87216,20 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aby
 bBW
 aic
-wpr
+ark
 rdI
 pXC
-rcV
-aiQ
-bHL
-jiQ
+pXC
+gyR
+anM
 sbr
-kBe
+agP
 ajp
-tbD
+rcV
 anM
 alF
 amq
@@ -87942,7 +87311,7 @@ bNO
 uOA
 mMd
 uqs
-tsk
+uqs
 fkX
 sOB
 aht
@@ -88104,16 +87473,16 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aby
 aaa
 aic
 aFa
 wtO
 wtO
-mXZ
-gyR
-vPZ
-hsR
+mDL
+aiQ
+gyU
 hBD
 waf
 cUr
@@ -88361,6 +87730,7 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aby
 aaa
 aic
@@ -88368,12 +87738,11 @@ upT
 wlO
 cnV
 cnV
-hPs
-hPs
-eIr
+gyR
+pxb
 oYQ
-hPs
-glZ
+gyR
+agP
 agP
 cCS
 alH
@@ -88618,6 +87987,7 @@ aaa
 aaa
 aaa
 aaa
+aaa
 acO
 aaa
 aic
@@ -88625,11 +87995,10 @@ jda
 wlO
 cnV
 cnV
-hPs
-xBO
-xdp
-nLS
-lBt
+gyR
+pxb
+anM
+anM
 uNz
 aiR
 akT
@@ -88875,6 +88244,7 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aby
 aaa
 aic
@@ -88882,11 +88252,10 @@ jda
 wlO
 cnV
 cnV
-hPs
-yhJ
-fVq
-tIf
-qbK
+gyR
+pxb
+anM
+anM
 aiR
 aiR
 akU
@@ -89132,18 +88501,18 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aby
 aaa
 aig
 jda
 fpQ
-fak
+kpN
 cnV
-hPs
-oZN
+gyR
 pxb
-rGp
-qbK
+anM
+anM
 aiR
 aka
 qeT
@@ -89389,6 +88758,7 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aby
 aht
 aic
@@ -89396,12 +88766,11 @@ aXi
 rNN
 rNN
 rNN
-hPs
-qgK
-uMv
-pAO
-vvm
-fQP
+gyR
+pxb
+anM
+anM
+aiR
 akb
 akW
 alK
@@ -89646,6 +89015,7 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aby
 aaa
 aic
@@ -89653,8 +89023,7 @@ aig
 aic
 aic
 tTx
-hPs
-hpP
+gyR
 hpP
 hpP
 hpP
@@ -89903,7 +89272,7 @@ aaa
 aaa
 aaa
 aaa
-gYo
+aaa
 aby
 aaa
 aaa
@@ -91264,7 +90633,7 @@ brg
 buh
 wQy
 bvo
-nJy
+qMC
 byA
 bzZ
 bzZ
@@ -91989,7 +91358,7 @@ auP
 asS
 asS
 ayg
-sSz
+oQp
 asS
 aBr
 aDJ
@@ -92046,7 +91415,7 @@ bsK
 xqq
 bsK
 bsK
-nAS
+bsK
 ftz
 bpY
 bTl
@@ -92807,7 +92176,7 @@ bsI
 tkl
 bwV
 mTf
-bsK
+ydL
 bsK
 bsK
 bEy
@@ -93070,10 +92439,10 @@ bBg
 bEy
 bsK
 rCo
-tcX
+bsK
 uIo
-rlT
-kpN
+bsK
+bsK
 bsK
 foK
 bpY
@@ -93366,7 +92735,7 @@ uoq
 tbj
 wYx
 tbj
-vxg
+uRk
 mZR
 nMP
 hQC
@@ -93623,8 +92992,8 @@ fyO
 snY
 ham
 cgT
-lZY
-fRc
+uRk
+uRk
 uRk
 slC
 sWj
@@ -93841,9 +93210,9 @@ bsK
 bsK
 bsK
 xqq
-gru
-lur
-bxa
+bsK
+bsK
+bsK
 bsK
 vlG
 bKG
@@ -94094,13 +93463,13 @@ qHa
 bpY
 brq
 bsK
-aij
-gma
-jGp
-frl
-rSF
-rSF
-brS
+bsK
+bsK
+bsK
+xqq
+bsK
+bsK
+bsK
 bsK
 bLL
 bpY
@@ -94143,7 +93512,7 @@ uRk
 jMt
 sWj
 evB
-iZq
+wZD
 oIA
 rkp
 xNX
@@ -94351,13 +93720,13 @@ bun
 bpY
 cIe
 bsK
-aYB
+bsK
 bsK
 bsK
 xqq
-rSF
-rSF
-brS
+bsK
+bsK
+bsK
 bsK
 tal
 bpY
@@ -94608,13 +93977,13 @@ bja
 bpY
 qqX
 bsK
-nOQ
-rek
-eQn
-cVE
-rSF
-rSF
-brS
+bsK
+bsK
+bsK
+xqq
+bsK
+bsK
+bsK
 bsK
 bMN
 bpY
@@ -94838,7 +94207,7 @@ aKY
 kVO
 aPE
 aVh
-ixx
+bah
 bah
 daB
 cpi
@@ -94865,13 +94234,13 @@ ccN
 bpY
 qqX
 bsK
-bsK
-bsK
-tcX
+bCv
+hBd
+hBd
 xqq
 diT
-xQM
-sdp
+bsK
+bsK
 bsK
 bMN
 bpY
@@ -95095,7 +94464,7 @@ aKY
 kVO
 aPE
 aVi
-ixx
+bah
 aXh
 cyM
 aZd
@@ -95125,7 +94494,7 @@ bsK
 bsK
 bsK
 bsK
-uoD
+bsK
 bsK
 bsK
 bsK
@@ -95352,7 +94721,7 @@ aRX
 aST
 aPE
 cpb
-ixx
+bah
 bah
 pVr
 cpi
@@ -97713,7 +97082,7 @@ bSd
 mUY
 vSL
 gNi
-nwz
+fby
 fby
 igl
 jhA
@@ -97971,7 +97340,7 @@ bSP
 bSP
 qOx
 qOx
-eqr
+gFX
 ihJ
 gFX
 rdQ
@@ -98961,7 +98330,7 @@ cct
 cct
 vRC
 aDZ
-mMA
+aDZ
 bhP
 bih
 bjm
@@ -101784,12 +101153,12 @@ aZo
 rWb
 bbE
 mOU
-aEj
-aKq
-aEj
-aEj
-aEj
-aEj
+bbI
+bbI
+bbI
+bbI
+bbI
+bbI
 biy
 bjw
 bjw
@@ -102039,12 +101408,12 @@ aWw
 aWw
 aWw
 rMn
-pvZ
-jYA
-aEj
-aFi
+bbI
+bcC
+bht
+raZ
 bfB
-aEj
+kew
 aZv
 aUC
 biz
@@ -102279,9 +101648,9 @@ cot
 kUq
 jvs
 jvs
-jHZ
-aEj
-aEj
+mqp
+nOV
+nOV
 bcI
 wDZ
 abh
@@ -102296,14 +101665,14 @@ aXx
 aYx
 aZq
 baA
-pvZ
+bbI
 bcB
+hmJ
+bfE
+pXH
+mOC
+lcO
 bbI
-bbI
-bbI
-bbI
-asG
-aEj
 asG
 bjw
 bkz
@@ -102534,11 +101903,11 @@ aGF
 aGF
 vpv
 qCS
-aEj
-aFi
-aFi
+nOV
+igy
+alx
 pPv
-aEj
+nOV
 fwI
 aNO
 aOZ
@@ -102550,17 +101919,17 @@ aUw
 uxO
 xNS
 jOm
-lIs
-wrE
+cCB
+cCB
 hKm
 bbI
-bcC
-bbI
+ykJ
 beL
-bfD
+beL
+bfH
+twZ
+yaE
 bbI
-asG
-aEj
 asG
 bjw
 bkA
@@ -102791,11 +102160,11 @@ cBp
 vpv
 osW
 hxQ
-aEj
-aFi
-aFi
+nOV
+seY
+hDh
 iMJ
-aEj
+nOV
 fwI
 wDZ
 hsN
@@ -102807,15 +102176,15 @@ anQ
 aVz
 aWz
 sLD
-uVo
 hzE
 hzE
+baC
 qXb
 udR
 dma
 pzn
 hgV
-bbI
+gVz
 bhr
 bbI
 asG
@@ -103048,11 +102417,11 @@ nCF
 nCF
 owj
 rrd
-aEj
+nOV
 plW
 nnF
 uUf
-aEj
+nOV
 fwI
 wDZ
 aPb
@@ -103063,15 +102432,15 @@ aTo
 aUx
 aVA
 qgE
-baC
-xEl
-aZr
 sql
+sql
+aZr
+baD
 jbo
-bdJ
-bdJ
+pKK
+wRW
 beM
-bfE
+bdJ
 bgK
 bhs
 bbI
@@ -103305,11 +102674,11 @@ sFN
 pdK
 tfI
 sfo
-aEj
+nOV
 rxv
-aFi
+uMv
 huJ
-aEj
+nOV
 fwI
 wDZ
 wDZ
@@ -103321,7 +102690,7 @@ aSk
 aWz
 ney
 gvi
-cCT
+aYB
 cCT
 baE
 bbI
@@ -103330,7 +102699,7 @@ bfH
 beN
 bfH
 bgL
-bht
+mXg
 bbI
 biC
 aaw
@@ -103562,11 +102931,11 @@ aFd
 rmc
 itC
 bfu
-aEj
-aEj
-aFi
-aEj
-aEj
+nOV
+nOV
+gma
+nOV
+nOV
 fwI
 aQk
 cDa
@@ -103577,15 +102946,15 @@ aTp
 aSk
 aUw
 aWB
-baB
+cCB
 nxG
 baB
 bqx
-bbK
+bbI
 bcF
 bfH
 beO
-prm
+beL
 bgM
 bhu
 bbI
@@ -103833,17 +103202,17 @@ aTq
 aTq
 ebw
 aUw
-mDL
+aWB
 aXy
-cCT
+aYB
 cCT
 baF
 bbK
 bcG
 bdM
 beP
-bfH
-pXH
+lIb
+mET
 bhv
 bbI
 aKq
@@ -104091,13 +103460,13 @@ aTr
 aUz
 aUw
 aWB
-baB
-baB
+cCB
+cCB
 fER
-pvZ
-bbI
-bbI
-bbI
+oYq
+bbK
+npb
+kwD
 bdI
 bfI
 bdI
@@ -104342,7 +103711,7 @@ aMw
 aQo
 aXC
 bcT
-jph
+cCB
 cCB
 aTs
 aUz
@@ -104351,10 +103720,10 @@ aWB
 aXA
 hvF
 ehK
-pvZ
-aaa
-aaa
-aaa
+vxg
+mxS
+mxS
+mxS
 bdI
 bfJ
 bdI
@@ -104605,17 +103974,17 @@ iDV
 sQt
 cdj
 aWB
-baB
+cCB
 cCB
 rCu
 pvZ
-aht
-aht
-aht
+oex
+oex
+oex
 bdI
 oPy
 bdI
-aht
+oex
 aEj
 aEj
 bHC
@@ -104862,7 +104231,7 @@ cDa
 aUA
 cdj
 aWB
-baB
+cCB
 cCB
 kRa
 aTy
@@ -105116,7 +104485,7 @@ aTv
 bfC
 oMH
 bcV
-vrq
+aSk
 cdj
 evg
 doQ
@@ -105376,7 +104745,7 @@ vQz
 eZj
 gcq
 vsw
-baB
+cCB
 cCB
 kRa
 pvZ
@@ -105632,7 +105001,7 @@ ueu
 bcV
 aSk
 sAD
-jaC
+aWB
 rAP
 cCB
 eJf
@@ -105889,7 +105258,7 @@ ujf
 cDa
 aTy
 kBu
-svW
+aTy
 pvZ
 xEt
 idl
@@ -106660,7 +106029,7 @@ beR
 dyL
 saR
 uzV
-igy
+saR
 wLu
 mBo
 gcb
@@ -106907,17 +106276,17 @@ xXo
 nLc
 aEj
 aKq
-nOV
-nOV
-nOV
-nOV
-nOV
-mqp
-nOV
-nOV
+aEj
+aEj
+aEl
+aEl
+aEl
+oYq
+aTy
+pvZ
 ubj
 qEF
-ydL
+ubj
 aTy
 hOn
 dCB
@@ -107164,17 +106533,17 @@ xXo
 qhh
 aEj
 aNV
-nOV
-fFG
-bCv
-hDh
-pXJ
-ucW
-alx
-nOV
+aEj
+aaa
+aaa
+aaa
+aaa
+rax
+aaa
+aTz
 dUZ
-dXc
-qfC
+szk
+uzX
 pvZ
 hUm
 tQp
@@ -107421,17 +106790,17 @@ xXo
 aEj
 aEj
 aNW
-nOV
-tOe
-pPZ
-knG
-bsS
-cZt
+aEj
+aaa
+aaa
+aaa
+aaa
+rax
 tMk
-vPh
-seY
-dXc
-baB
+aYF
+vRk
+szk
+cCB
 pvZ
 tOw
 dvH
@@ -107678,17 +107047,17 @@ pkw
 aaa
 aEj
 aKr
-nOV
-tOe
-icY
-eOW
-uyk
-qId
-bay
-lRn
-ydr
-pOn
-gzw
+aEj
+aaa
+aaa
+aaa
+aaa
+rax
+aaa
+aYF
+vRk
+szk
+cCB
 pvZ
 yeb
 iUS
@@ -107935,15 +107304,15 @@ pkw
 aaa
 aEj
 aEj
-nOV
-nSG
-aou
-sAR
-dkk
-sXQ
-xxA
-cTI
-cCB
+aEj
+aht
+aht
+aht
+aht
+rax
+aht
+aYE
+vRk
 szk
 cCB
 lOO
@@ -108202,7 +107571,7 @@ aaa
 aYF
 vRk
 szk
-pAT
+cCB
 pvZ
 aTy
 svW
@@ -108454,7 +107823,7 @@ aaa
 aaa
 aaa
 aaa
-wmJ
+rax
 aaa
 aYF
 gfW
@@ -110552,7 +109921,7 @@ iSq
 iSq
 hHZ
 sAK
-sAK
+bfD
 bwm
 jKq
 jKq
@@ -110561,7 +109930,7 @@ cVH
 jKq
 jKq
 jKq
-cdm
+aaa
 aaa
 aaa
 aaa
@@ -110809,8 +110178,8 @@ paM
 sZu
 jzW
 xDw
-sAK
-sAK
+bfD
+iHJ
 jKq
 rTs
 giR
@@ -110818,7 +110187,7 @@ qJH
 tWw
 oBb
 yjf
-cdm
+aht
 aaa
 aaa
 aaa
@@ -111075,7 +110444,7 @@ kyp
 jKq
 jKq
 jKq
-cdm
+aht
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -15824,6 +15824,7 @@
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/office/light,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bdQ" = (
@@ -16177,6 +16178,7 @@
 /area/station/cargo/storage)
 "beL" = (
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/office/light,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "beM" = (
@@ -16409,8 +16411,18 @@
 /turf/closed/wall,
 /area/station/maintenance/department/science)
 "bfE" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "bfH" = (
@@ -29705,6 +29717,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
+"cji" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "cjk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -34073,6 +34091,12 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
+"dlB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "dlS" = (
 /obj/structure/sign/warning/biohazard/directional/west,
 /obj/machinery/vending/drugs,
@@ -36615,6 +36639,14 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/service/jadedragon)
+"fqT" = (
+/obj/effect/landmark/start/shaft_miner,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "frC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -38824,12 +38856,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"gVz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "gVA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/event_spawn,
@@ -39309,14 +39335,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"hmJ" = (
-/obj/effect/landmark/start/shaft_miner,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "hng" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -39728,6 +39746,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"hCw" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "hCT" = (
 /obj/machinery/door/window/brigdoor/left/directional/south{
 	name = "Justice Chamber";
@@ -40419,6 +40448,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"ibE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/conveyor{
+	dir = 9;
+	id = "mining"
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "ibN" = (
 /turf/closed/mineral/iron,
 /area/centcom/asteroid/nearstation/bomb_site)
@@ -41111,11 +41152,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"iHJ" = (
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/structure/statue/petrified,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science)
 "iHM" = (
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
@@ -42613,11 +42649,28 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"jRD" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "mining"
+	},
+/obj/machinery/bouldertech/refinery,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "jRG" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"jRH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "jRZ" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/red{
@@ -42771,6 +42824,14 @@
 "jXV" = (
 /turf/open/floor/iron/white,
 /area/station/security/prison)
+"jXX" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "jYe" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass{
@@ -42897,23 +42958,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/crew_quarters/dorms)
-"kew" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/pickaxe{
-	pixel_x = 5
-	},
-/obj/item/shovel{
-	pixel_x = -5
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "kex" = (
 /obj/item/aicard,
 /obj/item/circuitboard/aicore,
@@ -43289,17 +43333,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
-"kwD" = (
-/obj/machinery/light/directional/east,
-/obj/machinery/requests_console{
-	department = "Mining";
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "kxj" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -43633,6 +43666,13 @@
 /obj/item/toy/basketball,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"kGQ" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "kHO" = (
 /obj/structure/bed/dogbed/renault,
 /mob/living/basic/pet/fox/renault,
@@ -44185,21 +44225,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/crew_quarters/dorms)
-"lcO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "lcP" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/misc/asteroid,
@@ -44961,13 +44986,6 @@
 /obj/item/bedsheet/orange,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"lIb" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "lIr" = (
 /obj/item/shrapnel/bullet{
 	pixel_x = 7
@@ -45959,9 +45977,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"mxS" = (
-/turf/closed/wall,
-/area/space)
 "mxT" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -46247,17 +46262,6 @@
 "mES" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
-"mET" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/railing/corner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "mFu" = (
 /obj/machinery/light/dim/directional/east,
 /obj/structure/table/wood/fancy/purple,
@@ -46430,10 +46434,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
-"mOC" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "mOL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
@@ -46652,14 +46652,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"mXg" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "mining"
-	},
-/obj/machinery/bouldertech/refinery,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "mXq" = (
 /obj/item/taperecorder,
 /obj/structure/table/wood,
@@ -47061,6 +47053,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"nkM" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/requests_console{
+	department = "Mining";
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "nlh" = (
 /obj/item/wheelchair,
 /turf/open/floor/plating,
@@ -47138,14 +47141,6 @@
 "noM" = (
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
-"npb" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/closet/wardrobe/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "nps" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/landmark/start/hangover/closet,
@@ -47548,6 +47543,11 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet/restrooms)
+"nHD" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/statue/petrified,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "nHK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
@@ -47935,6 +47935,23 @@
 /obj/item/spear,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"nVX" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2;
+	pixel_y = -1
+	},
+/obj/item/pickaxe{
+	pixel_x = 5
+	},
+/obj/item/shovel{
+	pixel_x = -5
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "nWb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47992,6 +48009,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"nXJ" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "nXS" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "Monkey Pen";
@@ -50422,14 +50446,6 @@
 /obj/effect/turf_decal/trimline/dark_blue/line,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
-"pKK" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "pKT" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
@@ -51073,6 +51089,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
+"qio" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/structure/railing/corner/end,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/rubble,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "qiw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/carbon_output{
 	dir = 1
@@ -51466,6 +51493,10 @@
 "qwn" = (
 /turf/closed/wall,
 /area/station/security/lockers)
+"qwv" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "qww" = (
 /obj/structure/table/glass,
 /obj/item/grenade/chem_grenade,
@@ -52186,13 +52217,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"raZ" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "rbo" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -53060,6 +53084,14 @@
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
+"rEg" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/closet/wardrobe/miner,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "rEh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -53976,6 +54008,10 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"ssu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "ssx" = (
 /obj/item/shard,
 /turf/open/floor/plating,
@@ -55381,17 +55417,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"twZ" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/railing/corner/end{
-	dir = 4
-	},
-/obj/structure/railing/corner/end,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/rubble,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "txB" = (
 /obj/structure/bookcase/random/adult,
 /obj/machinery/light/small/directional/south,
@@ -56410,6 +56435,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"ulH" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "ulV" = (
 /obj/structure/closet/secure_closet{
 	name = "contraband locker";
@@ -56797,6 +56833,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"uxX" = (
+/obj/effect/landmark/start/shaft_miner,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "uya" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -57652,6 +57693,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"vge" = (
+/turf/closed/wall,
+/area/space)
 "vgg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
@@ -60059,12 +60103,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
-"wRW" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "wTz" = (
 /turf/closed/wall,
 /area/station/engineering/atmos)
@@ -61648,18 +61686,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint/medical)
-"yaE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/conveyor{
-	dir = 9;
-	id = "mining"
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "yba" = (
 /obj/machinery/light/small/broken/directional/south,
 /obj/structure/cable,
@@ -61908,15 +61934,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"ykJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
 "ylb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -101411,9 +101428,9 @@ rMn
 bbI
 bcC
 bht
-raZ
+kGQ
 bfB
-kew
+nVX
 aZv
 aUC
 biz
@@ -101667,11 +101684,11 @@ aZq
 baA
 bbI
 bcB
-hmJ
-bfE
+fqT
+uxX
 pXH
-mOC
-lcO
+qwv
+bfE
 bbI
 asG
 bjw
@@ -101923,12 +101940,12 @@ cCB
 cCB
 hKm
 bbI
-ykJ
+jRH
 beL
 beL
 bfH
-twZ
-yaE
+qio
+ibE
 bbI
 asG
 bjw
@@ -102184,7 +102201,7 @@ udR
 dma
 pzn
 hgV
-gVz
+dlB
 bhr
 bbI
 asG
@@ -102432,13 +102449,13 @@ aTo
 aUx
 aVA
 qgE
-sql
+hCw
 sql
 aZr
 baD
 jbo
-pKK
-wRW
+jXX
+cji
 beM
 bdJ
 bgK
@@ -102699,7 +102716,7 @@ bfH
 beN
 bfH
 bgL
-mXg
+jRD
 bbI
 biC
 aaw
@@ -102954,7 +102971,7 @@ bbI
 bcF
 bfH
 beO
-beL
+ssu
 bgM
 bhu
 bbI
@@ -103211,8 +103228,8 @@ bbK
 bcG
 bdM
 beP
-lIb
-mET
+nXJ
+ulH
 bhv
 bbI
 aKq
@@ -103465,8 +103482,8 @@ cCB
 fER
 oYq
 bbK
-npb
-kwD
+rEg
+nkM
 bdI
 bfI
 bdI
@@ -103721,9 +103738,9 @@ aXA
 hvF
 ehK
 vxg
-mxS
-mxS
-mxS
+vge
+vge
+vge
 bdI
 bfJ
 bdI
@@ -110179,7 +110196,7 @@ sZu
 jzW
 xDw
 bfD
-iHJ
+nHD
 jKq
 rTs
 giR

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -4745,13 +4745,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "ark" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/item/toy/plush/skyrat/derg_plushie,
-/obj/structure/table/wood,
-/turf/open/floor/iron/white,
-/area/station/medical/psychology)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/hos)
 "arl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15792,6 +15789,12 @@
 /obj/machinery/griddle,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
+"bdw" = (
+/obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/landmark/secequipment,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "bdy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -16497,6 +16500,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel/monastery)
+"bgd" = (
+/obj/structure/training_machine,
+/obj/effect/turf_decal/trimline/yellow,
+/obj/item/target/clown,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "bge" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4;
@@ -23187,9 +23196,12 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/dock)
 "bGG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/station/service/chapel/dock)
+/area/station/cargo/storage)
 "bGH" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/space,
@@ -23347,10 +23359,9 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/dock)
 "bHL" = (
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/chapel/dock)
 "bHM" = (
 /turf/closed/wall/r_wall,
 /area/station/service/chapel/dock)
@@ -24346,6 +24357,12 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"bML" = (
+/obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "bMM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33827,6 +33844,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"cTg" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron/recharge_floor,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "cTI" = (
 /obj/structure/table,
 /obj/item/food/ready_donk/mac_n_cheese{
@@ -33855,6 +33879,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"cUH" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/machinery/ammo_workbench,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/range)
 "cVo" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -34828,6 +34867,15 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"dKy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "dKA" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 1
@@ -34931,6 +34979,9 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
+"dQs" = (
+/turf/open/floor/plating,
+/area/space/nearstation)
 "dQB" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/binary/tank_compressor{
@@ -35196,10 +35247,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/cytology)
-"edu" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "edJ" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/iron/white,
@@ -36650,12 +36697,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/dorms/barracks)
-"fkV" = (
-/obj/structure/training_machine,
-/obj/effect/turf_decal/trimline/yellow,
-/obj/item/target/clown,
-/turf/open/floor/iron/dark,
-/area/station/security/range)
 "fkX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -37783,6 +37824,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
+"gat" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/station/service/bar)
 "gaF" = (
 /obj/machinery/button/door{
 	id = "prisonereducation";
@@ -38301,6 +38346,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/research)
+"gth" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/item/toy/plush/skyrat/derg_plushie,
+/obj/structure/table/wood,
+/turf/open/floor/iron/white,
+/area/station/medical/psychology)
 "gtl" = (
 /obj/item/toy/crayon/black,
 /obj/item/toy/crayon/white{
@@ -39069,16 +39122,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"gVI" = (
-/obj/structure/cable,
-/obj/machinery/mech_bay_recharge_port{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/circuit/red,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "gVP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39593,6 +39636,16 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/commons/dorms/barracks)
+"hou" = (
+/obj/structure/cable,
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/red,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "hox" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
@@ -39727,13 +39780,6 @@
 /obj/structure/flora/bush/leavy/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central/fore)
-"hvt" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/service/chapel/dock)
 "hvF" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/bot,
@@ -39782,6 +39828,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"hxj" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "hxH" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
@@ -40680,15 +40730,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"ico" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "icp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -41151,9 +41192,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ixW" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/cargo/miningdock)
+/obj/item/toy/plush/skyrat/plushie_dan,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ixY" = (
 /obj/structure/sink/directional/west,
 /obj/structure/cable,
@@ -41373,6 +41414,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"iHd" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/obj/machinery/mechpad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "iHM" = (
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
@@ -41833,11 +41884,6 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"iZK" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "jaC" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -41854,6 +41900,20 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"jaR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "jbh" = (
 /obj/structure/railing{
 	dir = 8
@@ -41867,6 +41927,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
+"jbR" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/obj/effect/turf_decal/bot_red,
+/obj/effect/landmark/secequipment,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "jbV" = (
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
@@ -42860,9 +42926,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"jPb" = (
-/turf/open/space/basic,
-/area/station/command/bridge)
 "jPf" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
@@ -43390,13 +43453,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "kpN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/security/range)
 "kpW" = (
 /obj/machinery/door/airlock/glass,
 /obj/structure/cable,
@@ -44454,6 +44517,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"lcx" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "lcA" = (
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/engine,
@@ -44659,10 +44728,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"lls" = (
-/obj/item/virgin_mary,
-/turf/closed/wall,
-/area/station/service/chapel/monastery)
 "llP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -45948,12 +46013,6 @@
 "mkM" = (
 /turf/closed/wall,
 /area/station/medical/abandoned)
-"mlD" = (
-/obj/machinery/status_display/evac/directional/west,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/landmark/secequipment,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "mlP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -46526,8 +46585,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "mDL" = (
-/turf/open/floor/plating,
-/area/space/nearstation)
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/service/chapel/dock)
 "mDW" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -46580,10 +46643,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"mGR" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/dark,
-/area/station/service/bar)
 "mHy" = (
 /obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
 /turf/open/floor/wood,
@@ -47535,9 +47594,13 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
 "nwz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/station/service/chapel/dock)
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/structure/table/rolling,
+/obj/item/toy/plush/skyrat/engihound,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "nwH" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Atmospherics Tank - Toxins";
@@ -47597,20 +47660,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "nAS" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/machinery/ammo_workbench,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	name = "Chapel"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/range)
+/turf/open/floor/iron,
+/area/station/service/chapel/dock)
 "nBt" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -47999,6 +48053,15 @@
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /turf/open/floor/wood/parquet,
 /area/station/service/jadedragon)
+"nNc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 5
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "nNk" = (
 /obj/machinery/status_display/supply{
 	dir = 4;
@@ -48617,6 +48680,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"okP" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "olc" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bedroom"
@@ -48945,14 +49014,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"owq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/range)
 "owx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49758,26 +49819,6 @@
 	},
 /turf/closed/wall,
 /area/station/cargo/storage)
-"oYy" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
-"oYJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/structure/table/rolling,
-/obj/item/toy/plush/skyrat/engihound,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
 "oYQ" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "secmechbay";
@@ -49898,20 +49939,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
-"peh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "peY" = (
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50634,12 +50661,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"pFV" = (
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/range)
 "pGi" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -50752,12 +50773,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"pKg" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "pKx" = (
 /obj/structure/closet/crate/secure/weapon{
 	desc = "A secure clothing crate.";
@@ -50846,12 +50861,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"pMv" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Chapel"
-	},
-/turf/open/floor/iron,
-/area/station/service/chapel/dock)
 "pMI" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -51400,9 +51409,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qgK" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/recharge_floor,
+/turf/closed/wall/r_wall,
 /area/station/maintenance/department/security/lesser{
 	name = "Security Mech Maintenance Bay"
 	})
@@ -52619,14 +52626,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"rbm" = (
-/obj/structure/cable,
-/obj/machinery/computer/mech_bay_power_console,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/circuit/red,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "rbo" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -52660,10 +52659,9 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "rcV" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/hos)
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "rdn" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/engineering_welding,
@@ -52822,6 +52820,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"rin" = (
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "riH" = (
 /obj/structure/table,
 /turf/open/floor/iron/kitchen,
@@ -52927,12 +52930,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet/restrooms)
-"rmN" = (
-/obj/machinery/computer/security/telescreen/entertainment/directional/west,
-/obj/effect/turf_decal/bot_red,
-/obj/effect/landmark/secequipment,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "rmW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53118,18 +53115,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
-"rtb" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "rtd" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -53218,10 +53203,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"rvi" = (
-/obj/item/toy/plush/skyrat/plushie_dan,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "rvH" = (
 /obj/machinery/shower/directional/south,
 /obj/effect/turf_decal/trimline/blue/corner{
@@ -53290,6 +53271,28 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"rxB" = (
+/obj/structure/table,
+/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
+	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob";
+	pixel_y = 9;
+	pixel_x = -10
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 12
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "rxI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53327,10 +53330,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"rya" = (
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "ryi" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -53940,6 +53939,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"rWn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "rWE" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -54474,6 +54481,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"suo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/station/service/chapel/dock)
 "sut" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/space/basic,
@@ -57068,6 +57079,11 @@
 "uoS" = (
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
+"upd" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "upO" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
@@ -57609,13 +57625,6 @@
 /obj/effect/landmark/start/psychologist,
 /turf/open/floor/iron/white,
 /area/station/medical/psychology)
-"uLC" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "uLF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red{
@@ -57698,23 +57707,13 @@
 /turf/open/floor/wood,
 /area/station/security/prison)
 "uNz" = (
-/obj/structure/table,
-/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
-	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob";
-	pixel_y = 9;
-	pixel_x = -10
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 4;
-	pixel_y = -3
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 12
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 4;
-	pixel_y = -3
-	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/lesser{
 	name = "Security Mech Maintenance Bay"
@@ -57928,15 +57927,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
-"uXC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 5
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "uXE" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
@@ -58694,6 +58684,14 @@
 /obj/effect/turf_decal/trimline/purple/warning,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"vvF" = (
+/obj/structure/cable,
+/obj/machinery/computer/mech_bay_power_console,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/red,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
 "vvV" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "pod_arrive"
@@ -58855,11 +58853,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"vBh" = (
-/obj/effect/landmark/secequipment,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/dark,
-/area/station/security/office)
 "vBp" = (
 /obj/item/stack/pipe_cleaner_coil,
 /obj/structure/disposalpipe/segment{
@@ -59283,6 +59276,10 @@
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"vSA" = (
+/obj/item/virgin_mary,
+/turf/closed/wall,
+/area/station/service/chapel/monastery)
 "vSG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -61159,12 +61156,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
-"xkU" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "xlf" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -61409,6 +61400,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"xuk" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/security/lesser{
+	name = "Security Mech Maintenance Bay"
+	})
+"xum" = (
+/turf/open/space/basic,
+/area/station/command/bridge)
 "xur" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -61549,6 +61555,10 @@
 /obj/item/assembly/timer,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"xyn" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "xyB" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -62270,16 +62280,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"xYY" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/mapping_helpers/apc/cell_5k,
-/obj/structure/cable,
-/obj/machinery/mechpad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/department/security/lesser{
-	name = "Security Mech Maintenance Bay"
-	})
 "xZV" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -75120,7 +75120,7 @@ kcx
 cfN
 cfN
 cfN
-lls
+vSA
 bXJ
 cve
 cuK
@@ -76886,7 +76886,7 @@ aaa
 aaa
 aaa
 aaa
-mDL
+dQs
 bGF
 bHJ
 pbm
@@ -77400,9 +77400,9 @@ aaa
 aaa
 aaa
 mVM
-nwz
-bGG
-bGG
+suo
+bHL
+bHL
 aHE
 bKc
 eVb
@@ -77658,7 +77658,7 @@ hXW
 hXW
 hXW
 bNw
-bGG
+bHL
 bHN
 cqI
 bKd
@@ -77914,8 +77914,8 @@ bbU
 tow
 baK
 baK
-pMv
-bGG
+nAS
+bHL
 bHN
 bHM
 bHM
@@ -78171,8 +78171,8 @@ bbU
 baK
 bdZ
 bdZ
-hvt
-bGG
+mDL
+bHL
 bHN
 bGE
 bKe
@@ -87599,9 +87599,9 @@ cnN
 cnV
 gyR
 tuJ
-rmN
-mlD
-vBh
+jbR
+bdw
+rin
 ajo
 tbD
 dhu
@@ -87850,15 +87850,15 @@ aaa
 aby
 bBW
 aic
-nAS
+cUH
 rdI
 pXC
-pFV
+bML
 aiQ
-kpN
+rWn
 jiQ
 sbr
-pKg
+okP
 ajp
 tbD
 anM
@@ -87942,7 +87942,7 @@ bNO
 uOA
 mMd
 uqs
-ark
+gth
 fkX
 sOB
 aht
@@ -88110,10 +88110,10 @@ aic
 aFa
 wtO
 wtO
-owq
+kpN
 gyR
-uXC
-ico
+nNc
+dKy
 hBD
 waf
 cUr
@@ -88368,11 +88368,11 @@ upT
 wlO
 cnV
 cnV
-bHL
-bHL
+qgK
+qgK
 eIr
 oYQ
-bHL
+qgK
 glZ
 agP
 cCS
@@ -88625,12 +88625,12 @@ jda
 wlO
 cnV
 cnV
-bHL
-rbm
-peh
+qgK
+vvF
+jaR
 lBt
-rtb
-oYy
+xuk
+uNz
 aiR
 akT
 aiR
@@ -88882,8 +88882,8 @@ jda
 wlO
 cnV
 cnV
-bHL
 qgK
+cTg
 fVq
 tIf
 prm
@@ -89137,12 +89137,12 @@ aaa
 aig
 jda
 fpQ
-fkV
+bgd
 cnV
-bHL
-gVI
+qgK
+hou
 pxb
-xkU
+lcx
 prm
 aiR
 aka
@@ -89396,12 +89396,12 @@ aXi
 rNN
 rNN
 rNN
-bHL
-xYY
+qgK
+iHd
 uMv
-uNz
+rxB
 qbK
-rcV
+ark
 akb
 akW
 alK
@@ -89653,7 +89653,7 @@ aig
 aic
 aic
 tTx
-bHL
+qgK
 hpP
 hpP
 hpP
@@ -91989,7 +91989,7 @@ auP
 asS
 asS
 ayg
-jPb
+xum
 asS
 aBr
 aDJ
@@ -92046,7 +92046,7 @@ bsK
 xqq
 bsK
 bsK
-rvi
+ixW
 ftz
 bpY
 bTl
@@ -93073,7 +93073,7 @@ rCo
 tcX
 uIo
 rlT
-rya
+hxj
 bsK
 foK
 bpY
@@ -94838,7 +94838,7 @@ aKY
 kVO
 aPE
 aVh
-mGR
+gat
 bah
 daB
 cpi
@@ -95095,7 +95095,7 @@ aKY
 kVO
 aPE
 aVi
-mGR
+gat
 aXh
 cyM
 aZd
@@ -95352,7 +95352,7 @@ aRX
 aST
 aPE
 cpb
-mGR
+gat
 bah
 pVr
 cpi
@@ -97713,7 +97713,7 @@ bSd
 mUY
 vSL
 gNi
-oYJ
+nwz
 fby
 igl
 jhA
@@ -103585,7 +103585,7 @@ bbK
 bcF
 bfH
 beO
-ixW
+rcV
 bgM
 bhu
 bbI
@@ -103833,7 +103833,7 @@ aTq
 aTq
 ebw
 aUw
-uLC
+bGG
 aXy
 cCT
 cCT
@@ -104342,7 +104342,7 @@ aMw
 aQo
 aXC
 bcT
-edu
+xyn
 cCB
 aTs
 aUz
@@ -105116,7 +105116,7 @@ aTv
 bfC
 oMH
 bcV
-iZK
+upd
 cdj
 evg
 doQ
@@ -110561,7 +110561,7 @@ cVH
 jKq
 jKq
 jKq
-aaa
+cdm
 aaa
 aaa
 aaa
@@ -110818,7 +110818,7 @@ qJH
 tWw
 oBb
 yjf
-aht
+cdm
 aaa
 aaa
 aaa
@@ -111075,7 +111075,7 @@ kyp
 jKq
 jKq
 jKq
-aht
+cdm
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2165,11 +2165,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "aij" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/obj/structure/closet/secure_closet/armory_kiboko,
+/obj/structure/closet/secure_closet/armory_kiboko,
 /turf/open/floor/iron/dark,
-/area/station/security/office)
+/area/station/ai_monitored/security/armory)
 "aik" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron/dark,
@@ -3125,21 +3127,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "alx" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/line,
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/station/bitrunning/den)
+/turf/closed/wall/r_wall,
+/area/station/hallway/secondary/construction)
 "aly" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -4688,11 +4677,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/bridge)
-"aqL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/window/reinforced/spawner/directional/south,
-/turf/open/floor/plating,
-/area/station/engineering/lobby)
 "aqY" = (
 /obj/item/cardboard_cutout,
 /obj/item/cardboard_cutout,
@@ -13919,11 +13903,17 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
 /obj/structure/closet/crate/internals,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aXA" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aXB" = (
@@ -14279,9 +14269,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aYB" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "aYE" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -14949,39 +14939,24 @@
 /area/station/cargo/storage)
 "baC" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "baD" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
+/obj/structure/rack,
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "baE" = (
 /obj/machinery/light/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "baF" = (
 /obj/structure/table,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/item/clothing/gloves/cargo_gauntlet,
 /obj/item/clothing/gloves/cargo_gauntlet{
 	pixel_y = -3
@@ -16552,6 +16527,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"bgj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/board_number/one{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/engine,
+/area/station/bitrunning/den)
 "bgk" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -19167,9 +19157,6 @@
 /area/station/science/research)
 "bqx" = (
 /obj/structure/table,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -22354,8 +22341,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "bCv" = (
-/turf/closed/wall/r_wall,
-/area/station/security/tram)
+/obj/structure/lattice/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/toy/plush/moth{
+	name = "Wereni Moff"
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bCx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
@@ -24884,6 +24878,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"bPk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "bPn" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel"
@@ -30735,10 +30735,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"cnP" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "cnT" = (
 /obj/machinery/vending/security,
 /turf/open/floor/iron/dark,
@@ -33591,12 +33587,6 @@
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"cKx" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "cKz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -33630,6 +33620,12 @@
 "cLN" = (
 /turf/open/floor/plating,
 /area/station/security/prison)
+"cLU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "cMl" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -33676,6 +33672,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"cNR" = (
+/turf/closed/wall,
+/area/station/hallway/secondary/construction)
 "cOA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral,
@@ -33884,6 +33883,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"cYK" = (
+/turf/open/floor/wood/cold,
+/area/station/hallway/secondary/construction)
 "daB" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red{
@@ -34174,12 +34176,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"dmW" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "dnM" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -34227,6 +34223,9 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/end{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -34289,6 +34288,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"drv" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/rack,
+/obj/structure/cable,
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "drS" = (
 /obj/machinery/camera/preset/ordnance{
 	c_tag = "Bomb Testing Site2";
@@ -34375,6 +34381,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"dvc" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "dvH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/brown{
@@ -34727,6 +34740,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"dIf" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "dIn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/mapping_helpers/broken_floor,
@@ -34958,7 +34980,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
 "dUZ" = (
-/obj/machinery/light/directional/north,
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "dVp" = (
@@ -35064,6 +35089,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"eaU" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "jangarage";
+	name = "Custodial Closet Shutters"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron,
+/area/station/security/tram)
 "ebi" = (
 /obj/item/bedsheet/ian,
 /obj/structure/bed,
@@ -35196,6 +35230,9 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 2
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -35398,14 +35435,6 @@
 	},
 /turf/closed/wall,
 /area/station/commons/toilet/restrooms)
-"epY" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chem_lockdown";
-	name = "Chemistry Shutters"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "eqe" = (
 /obj/structure/rack,
 /obj/item/storage/backpack/satchel{
@@ -35670,6 +35699,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"eDM" = (
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/closed/wall/r_wall,
+/area/station/ai_monitored/security/armory)
+"eEa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/effect/landmark/start/bitrunner,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "eEp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -35905,6 +35946,23 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"eNz" = (
+/obj/structure/table,
+/obj/item/food/cornchips/blue{
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/cup/soda_cans/space_mountain_wind{
+	pixel_x = -7;
+	pixel_y = -1
+	},
+/obj/item/food/cornchips/red{
+	pixel_x = 3;
+	pixel_y = 6
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "eNF" = (
 /turf/closed/wall,
 /area/space/nearstation)
@@ -36189,6 +36247,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
+"faU" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/obj/item/kirbyplants/organic/plant7,
+/turf/open/floor/engine,
+/area/station/bitrunning/den)
 "faY" = (
 /turf/closed/wall,
 /area/centcom/asteroid/nearstation/bomb_site)
@@ -36347,6 +36416,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"fen" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "fer" = (
 /obj/machinery/power/shieldwallgen,
 /obj/structure/disposalpipe/segment{
@@ -36905,6 +36981,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/dorms/barracks)
+"fym" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "fyO" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible{
@@ -37005,15 +37088,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
-"fCf" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "fDg" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "IsolationCell";
@@ -37058,6 +37132,15 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
+"fEC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "fER" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -37293,7 +37376,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "fMp" = (
-/obj/machinery/light/directional/north,
 /obj/machinery/conveyor_switch/oneway{
 	id = "ShuttleLoad";
 	name = "Shuttle Load";
@@ -37305,6 +37387,7 @@
 	layer = 4;
 	pixel_y = 32
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "fMB" = (
@@ -37620,11 +37703,6 @@
 /obj/structure/railing/corner,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/secondary/entry)
-"fYI" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "fYZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/oxygen_output{
 	dir = 1
@@ -37651,13 +37729,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/hydroponics,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
-"gaq" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "gaF" = (
 /obj/machinery/button/door{
 	id = "prisonereducation";
@@ -37766,6 +37837,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
+"gen" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chem_lockdown";
+	name = "Chemistry Shutters"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "gfi" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 2
@@ -38008,10 +38087,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"glz" = (
-/obj/machinery/incident_display/delam/directional/west,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
 "glE" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Drone Bay Maintenance"
@@ -38021,16 +38096,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "gma" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Comissary Back Room"
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
-/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/department/cargo)
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "gmA" = (
 /obj/item/trash/bee,
 /obj/machinery/hydroponics/soil,
@@ -38082,12 +38154,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"gnT" = (
-/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
-	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob"
-	},
-/turf/open/floor/plating,
-/area/station/security/tram)
 "gnX" = (
 /obj/structure/chair{
 	dir = 1
@@ -38252,6 +38318,9 @@
 /obj/effect/turf_decal/bot,
 /mob/living/basic/sloth/paperwork{
 	name = "Taxes"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -38960,6 +39029,14 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"gXu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "gXT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -39398,11 +39475,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"hmS" = (
-/obj/structure/cable,
-/obj/structure/table_frame,
-/turf/open/floor/plating,
-/area/station/security/tram)
 "hng" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -39452,7 +39524,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/security/tram)
+/area/station/hallway/secondary/construction)
 "hpY" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39567,10 +39639,9 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
 "huJ" = (
-/obj/machinery/netpod,
 /obj/effect/decal/cleanable/robot_debris,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/bitrunning/den)
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "hvm" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/flora/bush/pointy/style_random,
@@ -39580,6 +39651,9 @@
 "hvF" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "hvW" = (
@@ -39697,11 +39771,12 @@
 /area/station/commons/fitness/recreation)
 "hzE" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "hzF" = (
@@ -39842,20 +39917,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "hDh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/effect/turf_decal/trimline/brown/line,
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/holopad,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/bitrunning/den)
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxiliary Base Construction"
@@ -39978,6 +40044,15 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/plating,
 /area/station/commons/toilet/restrooms)
+"hJf" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "hJO" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Prison Forestry"
@@ -39989,10 +40064,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "hKm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/airalarm/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "hKz" = (
@@ -40626,12 +40701,6 @@
 /obj/effect/decal/cleanable/glitter/blue,
 /turf/open/floor/glass,
 /area/station/service/jadedragon)
-"ifX" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "igd" = (
 /obj/structure/chair{
 	dir = 8
@@ -40649,9 +40718,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "igy" = (
-/obj/machinery/computer/quantum_console,
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/dark/smooth_corner,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/computer/order_console/bitrunning,
+/turf/open/floor/carpet/neon/simple/black/nodots,
 /area/station/bitrunning/den)
 "igC" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -40747,6 +40819,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"ile" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ilD" = (
 /obj/machinery/processor/slime,
 /turf/open/floor/iron/white,
@@ -40806,10 +40884,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"iqk" = (
-/obj/machinery/button/delam_scram,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
 "iqm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40955,9 +41029,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"ixz" = (
-/turf/open/floor/wood/cold,
-/area/station/security/tram)
 "ixN" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 5
@@ -41098,6 +41169,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"iCE" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "iDw" = (
 /obj/effect/turf_decal/vg_decals/atmos/mix{
 	dir = 1
@@ -41319,6 +41397,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"iJL" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "iKb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
@@ -41386,11 +41470,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "iMJ" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/byteforge,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/bitrunning/den)
+/obj/machinery/light/broken,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "iNN" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/table,
@@ -41612,9 +41694,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"iWF" = (
-/turf/closed/wall,
-/area/station/security/tram)
 "iWV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -41983,6 +42062,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"joe" = (
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
 "jor" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -42072,6 +42154,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"jrX" = (
+/obj/machinery/light/floor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "jsf" = (
 /obj/item/toy/katana,
 /turf/open/floor/plating,
@@ -42144,7 +42233,7 @@
 "jvs" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
-/area/station/bitrunning/den)
+/area/station/maintenance/department/cargo)
 "jvF" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8;
@@ -42218,6 +42307,11 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
+"jyc" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/quantum_server,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/bitrunning/den)
 "jyg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42816,10 +42910,6 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"jUH" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "jUP" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -43180,13 +43270,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"koW" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/rack,
-/obj/structure/cable,
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "kpE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -43493,6 +43576,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
+"kBl" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "kBm" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -43553,10 +43642,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms)
-"kCw" = (
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/closed/wall/r_wall,
-/area/station/ai_monitored/security/armory)
 "kCP" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -43959,6 +44044,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine)
+"kRv" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/turf/open/floor/iron/stairs{
+	dir = 1
+	},
+/area/station/bitrunning/den)
 "kRH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -43983,6 +44074,11 @@
 /obj/structure/closet/crate/critter,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
+"kSu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/byteforge,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/bitrunning/den)
 "kSA" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -44101,11 +44197,6 @@
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"kVv" = (
-/obj/structure/cable,
-/obj/machinery/computer,
-/turf/open/floor/plating,
-/area/station/security/tram)
 "kVG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44259,6 +44350,12 @@
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
+"lcB" = (
+/obj/structure/sign/poster/contraband/random/directional/west,
+/obj/machinery/netpod,
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/bitrunning/den)
 "lcG" = (
 /obj/item/clothing/suit/caution{
 	pixel_y = 8
@@ -44561,15 +44658,15 @@
 /obj/item/statuebust,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
+"lpK" = (
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "lqc" = (
 /obj/item/toy/gun,
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
-"lqk" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "lqm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/button/door{
@@ -45335,6 +45432,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
+"lVC" = (
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "lVG" = (
 /obj/effect/turf_decal/vg_decals/radiation_huge,
 /obj/structure/cable/layer1,
@@ -45823,10 +45930,20 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "mqp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/closed/wall,
+/obj/effect/turf_decal/board_number/two{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/station/bitrunning/den)
 "mqD" = (
 /obj/machinery/cryopod{
@@ -46406,10 +46523,11 @@
 "mKE" = (
 /turf/closed/wall,
 /area/station/medical/medbay/lobby)
-"mLl" = (
-/obj/structure/table_frame,
-/turf/open/floor/wood/cold,
-/area/station/security/tram)
+"mKJ" = (
+/obj/structure/cable,
+/obj/machinery/computer,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
 "mLv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -46873,6 +46991,15 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
+"ncr" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "ndc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -47085,6 +47212,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/artgallery)
+"nju" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/item/modular_computer/laptop/preset/civilian{
+	pixel_y = 5;
+	pixel_x = 2
+	},
+/obj/structure/table,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "nkd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -47138,6 +47276,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"nmX" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "nnb" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/light_switch{
@@ -47174,24 +47316,8 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/bitrunning/den)
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "noM" = (
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
@@ -47323,8 +47449,20 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"nxF" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "nxG" = (
 /obj/effect/landmark/start/cargo_technician,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "nxT" = (
@@ -47942,6 +48080,11 @@
 /obj/structure/flora/bush/jungle/b/style_random,
 /turf/open/floor/grass,
 /area/station/medical/treatment_center)
+"nUc" = (
+/obj/structure/cable,
+/obj/structure/table_frame,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
 "nUg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -48080,15 +48223,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
-"nYS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	id = "jangarage";
-	name = "Custodial Closet Shutters"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/security/tram)
 "nZw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock{
@@ -48150,6 +48284,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
+"oei" = (
+/obj/machinery/button/delam_scram,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "oex" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -48179,6 +48317,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
+"ofn" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "oft" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/structure/disposalpipe/segment{
@@ -48404,14 +48552,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
-"onu" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "onD" = (
 /obj/structure/table,
 /obj/effect/spawner/random/clothing/costume,
@@ -48902,6 +49042,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
+"oCS" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "oDk" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -48954,6 +49101,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"oEn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "oEz" = (
 /obj/item/inspector{
 	pixel_x = -5;
@@ -49091,13 +49244,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
-"oJu" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "oJx" = (
 /obj/machinery/light_switch{
 	pixel_x = 22;
@@ -49178,6 +49324,13 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/commons/toilet/restrooms)
+"oMB" = (
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "oMH" = (
 /obj/structure/table,
 /obj/item/airlock_painter/decal,
@@ -49522,7 +49675,7 @@
 	name = "Custodial Closet Shutters"
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/tram)
+/area/station/hallway/secondary/construction)
 "oZv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
@@ -49707,9 +49860,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"phy" = (
-/turf/open/floor/plating,
-/area/station/security/tram)
 "phC" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -49840,18 +49990,9 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/generic,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/start/bitrunner,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/bitrunning/den)
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "pmc" = (
 /turf/closed/wall,
 /area/station/service/jadedragon)
@@ -49953,7 +50094,6 @@
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "prr" = (
-/obj/machinery/light/directional/south,
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
 	id = "ShuttleUnload";
@@ -49961,6 +50101,7 @@
 	pixel_x = 6;
 	pixel_y = 20
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "prB" = (
@@ -50068,8 +50209,12 @@
 /area/space/nearstation)
 "pxb" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/security/tram)
+/obj/machinery/door/poddoor/shutters{
+	id = "jangarage";
+	name = "Custodial Closet Shutters"
+	},
+/turf/open/floor/iron/dark,
+/area/station/hallway/secondary/construction)
 "pxO" = (
 /obj/item/transfer_valve{
 	pixel_x = -5
@@ -50493,6 +50638,12 @@
 /obj/effect/turf_decal/trimline/dark_blue/line,
 /turf/open/floor/iron/dark,
 /area/station/security/lockers)
+"pKC" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "pKT" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
@@ -50649,8 +50800,8 @@
 /obj/item/reagent_containers/cup/soda_cans/space_mountain_wind{
 	pixel_x = 5
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/bitrunning/den)
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "pPI" = (
 /obj/structure/table,
 /obj/machinery/camera/directional/north{
@@ -50691,6 +50842,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/service/library/artgallery)
+"pQJ" = (
+/obj/structure/sign/warning/vacuum/external/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "pQQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/broken_floor,
@@ -50740,6 +50895,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/security/prison)
+"pTn" = (
+/obj/structure/table_frame,
+/turf/open/floor/wood/cold,
+/area/station/hallway/secondary/construction)
 "pTy" = (
 /obj/effect/turf_decal/trimline/blue/line{
 	dir = 1
@@ -50764,12 +50923,6 @@
 /obj/structure/displaycase/forsale/kitchen,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
-"pVv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "pVD" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
@@ -51053,13 +51206,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qgK" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor/shutters{
-	id = "jangarage";
-	name = "Custodial Closet Shutters"
+/obj/machinery/computer/quantum_console{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/tram)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/bitrunning/den)
 "qgM" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
@@ -51227,14 +51378,6 @@
 "qml" = (
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/blueshield)
-"qmB" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/obj/structure/closet/secure_closet/armory_kiboko,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "qnJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51294,6 +51437,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"qoM" = (
+/obj/effect/turf_decal/bot_blue,
+/obj/structure/rack,
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/security/armory)
 "qoS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -51755,6 +51904,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "qEM" = (
@@ -52031,6 +52181,13 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"qQI" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "qQQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -52223,6 +52380,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"qYY" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "qZc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -52304,6 +52470,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"rdm" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "rdn" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/engineering_welding,
@@ -52372,6 +52544,11 @@
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms/barracks)
+"rfX" = (
+/obj/machinery/netpod,
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/bitrunning/den)
 "rfZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -52884,11 +53061,10 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
 "rxv" = (
-/obj/machinery/netpod,
 /obj/structure/sign/poster/random/directional/north,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/bitrunning/den)
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "rxA" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -53009,6 +53185,9 @@
 /obj/machinery/light_switch{
 	pixel_x = 25;
 	pixel_y = -9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
@@ -53207,15 +53386,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
-"rIn" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
+"rHV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/plating,
+/area/station/engineering/lobby)
 "rIw" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -53478,12 +53653,6 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
-"rSN" = (
-/obj/effect/turf_decal/bot_blue,
-/obj/structure/rack,
-/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case,
-/turf/open/floor/iron/dark,
-/area/station/ai_monitored/security/armory)
 "rSQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -53771,12 +53940,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "seY" = (
-/obj/machinery/quantum_server,
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 4
+/obj/item/paper/crumpled/awaymissions/moonoutpost19/hastey_note{
+	default_raw_text = "<i>19 06 2554</i><br><br><i>I fucking knew it, I could not fix it!! We ran out of time to finish the Duty free bar... So if you find this um....<br><br>IOU, 1 Duty Free bar</i><br><br>Bob"
 	},
-/area/station/bitrunning/den)
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
 "sfo" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -54474,7 +54642,6 @@
 /area/station/medical/paramedic)
 "sLD" = (
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -54643,15 +54810,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"sUI" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "sUP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55354,12 +55512,6 @@
 /obj/item/food/fishmeat,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"tra" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "try" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater,
 /turf/open/floor/iron,
@@ -55591,6 +55743,10 @@
 /obj/structure/table/glass,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"tCq" = (
+/obj/structure/sign/delam_procedure,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "tCC" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -55796,6 +55952,13 @@
 "tLe" = (
 /turf/closed/wall,
 /area/station/security/execution/education)
+"tLH" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/machinery/light/small/directional/east,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "tLK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -55809,12 +55972,29 @@
 	},
 /turf/closed/wall,
 /area/station/cargo/sorting)
-"tMk" = (
-/obj/item/toy/plush/moth{
-	name = "Wereni Moff"
+"tMb" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/chair/office{
+	color = "#52B4E9";
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/station/bitrunning/den)
+"tMk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "tMs" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -56958,6 +57138,9 @@
 /area/station/cargo/storage)
 "uzX" = (
 /obj/machinery/light/directional/south,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "uAh" = (
@@ -57000,6 +57183,12 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"uBG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/station/bitrunning/den)
 "uCe" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
@@ -57103,6 +57292,23 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"uIa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 7
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "uIo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57221,10 +57427,8 @@
 /area/station/maintenance/department/engine)
 "uMv" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/bitrunning/den)
+/turf/open/floor/plating,
+/area/station/hallway/secondary/construction)
 "uMY" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -57243,7 +57447,7 @@
 "uNz" = (
 /obj/structure/table_frame,
 /turf/open/floor/plating,
-/area/station/security/tram)
+/area/station/hallway/secondary/construction)
 "uOA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -57362,6 +57566,21 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
+"uSY" = (
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/board_number/three{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/station/bitrunning/den)
 "uTi" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/cell_5k,
@@ -57385,19 +57604,10 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 8
-	},
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/oil,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/station/bitrunning/den)
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "uUr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -57452,6 +57662,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
+"uWy" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "uXE" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/delivery,
@@ -58036,6 +58253,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "vqE" = (
@@ -58265,11 +58485,17 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "vxg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/door/airlock/mining/glass{
+	name = "Comissary Back Room"
 	},
-/turf/closed/wall,
-/area/station/cargo/storage)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "vxp" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
@@ -58464,13 +58690,6 @@
 "vHS" = (
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
-"vHT" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "vIa" = (
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark/side{
@@ -58570,6 +58789,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
+"vNk" = (
+/obj/machinery/incident_display/delam/directional/west,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "vNr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
@@ -58609,6 +58832,13 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/command/heads_quarters/blueshield)
+"vOi" = (
+/obj/effect/landmark/start/bitrunner,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "vOw" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -58621,13 +58851,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"vOx" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "vOB" = (
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
@@ -59283,6 +59506,10 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space)
+"wmr" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "wns" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plating,
@@ -60007,10 +60234,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/department/engine)
-"wNs" = (
-/obj/structure/sign/delam_procedure,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
 "wNI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -60504,12 +60727,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"xeR" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/chemistry)
 "xeZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60713,6 +60930,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
+"xmq" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "xmE" = (
 /obj/structure/chair{
 	dir = 8
@@ -60943,6 +61169,12 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/jadedragon)
+"xva" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/chemistry)
 "xvO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -61368,6 +61600,12 @@
 "xLv" = (
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"xLx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/office)
 "xLC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -61500,6 +61738,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
+"xPM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start/bitrunner,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "xQn" = (
 /obj/effect/turf_decal/stripes{
 	dir = 5
@@ -61598,6 +61846,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"xUQ" = (
+/obj/structure/table,
+/obj/item/food/ready_donk/mac_n_cheese{
+	pixel_y = 3;
+	pixel_x = 2
+	},
+/obj/item/food/ready_donk/nachos_grandes{
+	pixel_y = 7
+	},
+/obj/item/food/ready_donk/donkhiladas{
+	pixel_y = 11;
+	pixel_x = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/carpet/neon/simple/black/nodots,
+/area/station/bitrunning/den)
 "xUU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61839,7 +62104,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "ydL" = (
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "ydZ" = (
@@ -84489,7 +84754,7 @@ oOf
 ahL
 aii
 aiL
-rSN
+qoM
 ajg
 ajP
 wLf
@@ -85004,7 +85269,7 @@ ahL
 sNS
 ajR
 bFP
-fYI
+baD
 bGT
 ulV
 akN
@@ -85258,7 +85523,7 @@ ntT
 apd
 iJJ
 ahL
-qmB
+aij
 bCg
 ewj
 ewj
@@ -85514,10 +85779,10 @@ aew
 iBg
 pah
 dfW
-kCw
+eDM
 bnC
 aiO
-koW
+drv
 ajj
 ajT
 akP
@@ -86592,7 +86857,7 @@ aVS
 aVS
 aVS
 aVS
-nYS
+eaU
 bbW
 aVS
 aVS
@@ -87314,7 +87579,7 @@ rdI
 pXC
 pXC
 gyR
-aij
+xLx
 sbr
 agP
 ajp
@@ -87827,11 +88092,11 @@ upT
 wlO
 cnV
 cnV
-bCv
-qgK
+alx
+pxb
 oYQ
-bCv
-iWF
+alx
+cNR
 agP
 cCS
 alH
@@ -88084,10 +88349,10 @@ jda
 wlO
 cnV
 cnV
-bCv
-pxb
-phy
-phy
+alx
+uMv
+joe
+joe
 uNz
 aiR
 akT
@@ -88341,10 +88606,10 @@ jda
 wlO
 cnV
 cnV
-bCv
-kVv
-gnT
-ixz
+alx
+mKJ
+seY
+cYK
 aiR
 aiR
 akU
@@ -88598,10 +88863,10 @@ jda
 fpQ
 kpN
 cnV
-bCv
-pxb
-phy
-mLl
+alx
+uMv
+joe
+pTn
 aiR
 aka
 qeT
@@ -88855,10 +89120,10 @@ aXi
 rNN
 rNN
 rNN
-bCv
-hmS
+alx
+nUc
 uNz
-mLl
+pTn
 aiR
 akb
 akW
@@ -89112,7 +89377,7 @@ aig
 aic
 aic
 tTx
-bCv
+alx
 hpP
 hpP
 hpP
@@ -90722,7 +90987,7 @@ brg
 buh
 wQy
 bvo
-epY
+gen
 byA
 bzZ
 bzZ
@@ -92824,7 +93089,7 @@ uoq
 tbj
 wYx
 tbj
-glz
+vNk
 mZR
 nMP
 hQC
@@ -93081,8 +93346,8 @@ fyO
 snY
 ham
 cgT
-wNs
-iqk
+tCq
+oei
 uRk
 slC
 sWj
@@ -93299,9 +93564,9 @@ bsK
 bsK
 bsK
 xqq
-vHT
-rIn
-oJu
+qQI
+ncr
+fym
 bsK
 vlG
 bKG
@@ -93552,13 +93817,13 @@ qHa
 bpY
 brq
 bsK
+lpK
+wmr
+rdm
+gma
 ydL
-cnP
-cKx
-onu
-lqk
-lqk
-gaq
+ydL
+dvc
 bsK
 bLL
 bpY
@@ -93601,7 +93866,7 @@ uRk
 jMt
 sWj
 evB
-vOx
+oCS
 oIA
 rkp
 xNX
@@ -93809,13 +94074,13 @@ bun
 bpY
 cIe
 bsK
-jUH
+aYB
 bsK
 bsK
 xqq
-lqk
-lqk
-gaq
+ydL
+ydL
+dvc
 bsK
 tal
 bpY
@@ -94066,13 +94331,13 @@ bja
 bpY
 qqX
 bsK
-xeR
-dmW
-tra
-ifX
-lqk
-lqk
-gaq
+iJL
+kBl
+xva
+pKC
+ydL
+ydL
+dvc
 bsK
 bMN
 bpY
@@ -94328,8 +94593,8 @@ bsK
 tcX
 xqq
 diT
-sUI
-fCf
+dIf
+nxF
 bsK
 bMN
 bpY
@@ -94583,7 +94848,7 @@ bsK
 bsK
 bsK
 bsK
-pVv
+ile
 bsK
 bsK
 bsK
@@ -97429,7 +97694,7 @@ bSP
 bSP
 qOx
 qOx
-aqL
+rHV
 ihJ
 gFX
 rdQ
@@ -101737,9 +102002,9 @@ cot
 kUq
 jvs
 jvs
-mqp
-nOV
-nOV
+jHZ
+aEj
+aEj
 bcI
 wDZ
 abh
@@ -101992,11 +102257,11 @@ aGF
 aGF
 vpv
 qCS
-nOV
-igy
-alx
+aEj
+aFi
+aFi
 pPv
-nOV
+aEj
 fwI
 aNO
 aOZ
@@ -102008,8 +102273,8 @@ aUw
 uxO
 xNS
 jOm
-cCB
-cCB
+hDh
+nmX
 hKm
 bbI
 bcC
@@ -102249,11 +102514,11 @@ cBp
 vpv
 osW
 hxQ
-nOV
-seY
-hDh
+aEj
+aFi
+aFi
 iMJ
-nOV
+aEj
 fwI
 wDZ
 hsN
@@ -102266,7 +102531,7 @@ aVz
 aWz
 sLD
 hzE
-hzE
+baC
 baC
 qXb
 udR
@@ -102506,11 +102771,11 @@ nCF
 nCF
 owj
 rrd
-nOV
+aEj
 plW
 nnF
 uUf
-nOV
+aEj
 fwI
 wDZ
 aPb
@@ -102521,10 +102786,10 @@ aTo
 aUx
 aVA
 qgE
-sql
-sql
+hJf
+ofn
 aZr
-baD
+sql
 jbo
 bdJ
 bdJ
@@ -102763,11 +103028,11 @@ sFN
 pdK
 tfI
 sfo
-nOV
+aEj
 rxv
-uMv
+aFi
 huJ
-nOV
+aEj
 fwI
 wDZ
 wDZ
@@ -102779,7 +103044,7 @@ aSk
 aWz
 ney
 gvi
-aYB
+cCT
 cCT
 baE
 bbI
@@ -103020,11 +103285,11 @@ aFd
 rmc
 itC
 bfu
-nOV
-nOV
-gma
-nOV
-nOV
+aEj
+aEj
+aFi
+aEj
+aEj
 fwI
 aQk
 cDa
@@ -103035,7 +103300,7 @@ aTp
 aSk
 aUw
 aWB
-cCB
+baB
 nxG
 baB
 bqx
@@ -103293,7 +103558,7 @@ ebw
 aUw
 aWB
 aXy
-aYB
+cCT
 cCT
 baF
 bbK
@@ -103549,10 +103814,10 @@ aTr
 aUz
 aUw
 aWB
-cCB
-cCB
+baB
+baB
 fER
-oYq
+pvZ
 bbI
 bbI
 bbI
@@ -103809,7 +104074,7 @@ aWB
 aXA
 hvF
 ehK
-vxg
+pvZ
 aaa
 aaa
 aaa
@@ -104063,7 +104328,7 @@ iDV
 sQt
 cdj
 aWB
-cCB
+baB
 cCB
 rCu
 pvZ
@@ -104320,7 +104585,7 @@ cDa
 aUA
 cdj
 aWB
-cCB
+baB
 cCB
 kRa
 aTy
@@ -104834,7 +105099,7 @@ vQz
 eZj
 gcq
 vsw
-cCB
+baB
 cCB
 kRa
 pvZ
@@ -105090,7 +105355,7 @@ ueu
 bcV
 aSk
 sAD
-aWB
+xmq
 rAP
 cCB
 eJf
@@ -105347,7 +105612,7 @@ ujf
 cDa
 aTy
 kBu
-aTy
+svW
 pvZ
 xEt
 idl
@@ -106118,7 +106383,7 @@ beR
 dyL
 saR
 uzV
-saR
+qYY
 wLu
 mBo
 gcb
@@ -106365,17 +106630,17 @@ xXo
 nLc
 aEj
 aKq
-aEj
-aEj
-aEl
-aEl
-aEl
-oYq
-aTy
-pvZ
+nOV
+nOV
+nOV
+nOV
+nOV
+uBG
+nOV
+nOV
 ubj
 qEF
-ubj
+uWy
 aTy
 hOn
 dCB
@@ -106622,17 +106887,17 @@ xXo
 qhh
 aEj
 aNV
-aEj
-aaa
-aaa
-aaa
-aaa
-rax
-aaa
-aTz
+nOV
+lcB
+bgj
+kRv
+lVC
+eEa
+oMB
+nOV
 dUZ
-szk
-uzX
+oEn
+jrX
 pvZ
 hUm
 tQp
@@ -106879,17 +107144,17 @@ xXo
 aEj
 aEj
 aNW
-aEj
-aaa
-aaa
-aaa
-aaa
-rax
+nOV
+rfX
+mqp
+kSu
+uIa
+gXu
 tMk
-aYF
-vRk
-szk
-cCB
+vxg
+fEC
+oEn
+baB
 pvZ
 tOw
 dvH
@@ -107136,17 +107401,17 @@ pkw
 aaa
 aEj
 aKr
-aEj
-aaa
-aaa
-aaa
-aaa
-rax
-aaa
-aYF
-vRk
-szk
-cCB
+nOV
+rfX
+uSY
+qgK
+nju
+xPM
+vOi
+iCE
+fen
+cLU
+bPk
 pvZ
 yeb
 iUS
@@ -107393,15 +107658,15 @@ pkw
 aaa
 aEj
 aEj
-aEj
-aht
-aht
-aht
-aht
-rax
-aht
-aYE
-vRk
+nOV
+faU
+tMb
+jyc
+igy
+eNz
+tLH
+xUQ
+cCB
 szk
 cCB
 lOO
@@ -107660,7 +107925,7 @@ aaa
 aYF
 vRk
 szk
-cCB
+pQJ
 pvZ
 aTy
 svW
@@ -107912,7 +108177,7 @@ aaa
 aaa
 aaa
 aaa
-rax
+bCv
 aaa
 aYF
 gfW


### PR DESCRIPTION
Fixed mapped the following map bugs on Pubby Station

#515 -Remove duped Tile items
#520 - Extended Armory and added missing Items
#523 - Took Shutdown Button from Polly and install in SM access airlock
#524 - Corrected Subcontractors mistake installing Temp regs
#525 - Removed the Plumbing Shutter till we can get shutter working independently of the other Chem shutters